### PR TITLE
Feat format translation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "dask",
     "distributed",
     "geopandas",
+    "numpy >= 1.26.4, < 2",
     "pandas",
     "polars",
     "pyarrow",

--- a/tstore/archive/io.py
+++ b/tstore/archive/io.py
@@ -56,14 +56,6 @@ def get_tstore_structure(base_dir):
     return metadata["tstore_structure"]
 
 
-def get_time_var(base_dir):
-    """Get TStore time variable."""
-    from tstore.archive.metadata.readers import read_tstore_metadata
-
-    metadata = read_tstore_metadata(base_dir=base_dir)
-    return metadata["time_var"]
-
-
 def get_id_var(base_dir):
     """Get TStore ID variable."""
     from tstore.archive.metadata.readers import read_tstore_metadata

--- a/tstore/archive/metadata/writers.py
+++ b/tstore/archive/metadata/writers.py
@@ -16,12 +16,11 @@ def _write_yaml_metadata(metadata, fpath):
         yaml.dump(metadata, file)
 
 
-def write_tstore_metadata(base_dir, ts_variables, id_var, time_var, tstore_structure, partitioning):
+def write_tstore_metadata(base_dir, ts_variables, id_var, tstore_structure, partitioning):
     """Write TStore metadata file."""
     metadata_fpath = define_metadata_filepath(base_dir)
     metadata = {}
     metadata["ts_variables"] = ts_variables
-    metadata["time_var"] = time_var
     metadata["id_var"] = id_var
     metadata["tstore_structure"] = tstore_structure
     metadata["partitioning"] = partitioning

--- a/tstore/backend.py
+++ b/tstore/backend.py
@@ -97,6 +97,10 @@ def re_set_dataframe_index(df: DataFrame, index_var: Optional[str] = None) -> Da
         df = df.reset_index(drop=False)
 
     if index_var is not None:
+        # Cast column before setting it as index to prevent issue with PyArrow index in Dask dataframe
+        if df[index_var].dtype.name == "timestamp[ns][pyarrow]":
+            df[index_var] = df[index_var].astype("datetime64[ns]")
+
         df = df.set_index(index_var)
 
     return df

--- a/tstore/backend.py
+++ b/tstore/backend.py
@@ -60,6 +60,17 @@ def change_backend(
     raise TypeError(f"Unsupported type: {type(obj).__module__}.{type(obj).__qualname__}")
 
 
+def remove_dataframe_index(df: DataFrame) -> DataFrame:
+    """Remove the index of a DataFrame and keep it as a regular column."""
+    if isinstance(df, (PolarsDataFrame, PyArrowDataFrame)):
+        return df
+
+    if df.index.name is not None:
+        df = df.reset_index(drop=False)
+
+    return df
+
+
 def re_set_dataframe_index(df: DataFrame, index_var: Optional[str] = None) -> DataFrame:
     """Remove existing dataframe index and set a new one if index_var is provided."""
     if isinstance(df, (PolarsDataFrame, PyArrowDataFrame)):

--- a/tstore/backend.py
+++ b/tstore/backend.py
@@ -1,6 +1,6 @@
 """Define possible backends for type hinting."""
 
-from typing import Literal, Union
+from typing import Literal, TypeVar, Union
 
 import dask.dataframe as dd
 import pandas as pd
@@ -20,25 +20,37 @@ PolarsDataFrame = pl.DataFrame
 PyArrowDataFrame = pa.Table
 DataFrame = Union[DaskDataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame]
 
-
-def change_backend(df: DataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
-    """Change the backend of a dataframe."""
-    if isinstance(df, DaskDataFrame):
-        return _change_backend_from_dask(df, new_backend, **backend_kwargs)
-
-    if isinstance(df, PandasDataFrame):
-        return _change_backend_from_pandas(df, new_backend, **backend_kwargs)
-
-    if isinstance(df, PolarsDataFrame):
-        return _change_backend_from_polars(df, new_backend, **backend_kwargs)
-
-    if isinstance(df, PyArrowDataFrame):
-        return _change_backend_from_pyarrow(df, new_backend, **backend_kwargs)
-
-    raise TypeError(f"Unsupported dataframe type: {type(df).__module__}.{type(df).__qualname__}")
+DaskSeries = dd.Series
+PandasSeries = pd.Series
+PolarsSeries = pl.Series
+PyArrowSeries = pa.Array
+Series = Union[DaskSeries, PandasSeries, PolarsSeries, PyArrowSeries]
 
 
-def _change_backend_from_dask(df: DaskDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
+T = TypeVar("T", DataFrame, Series)
+
+
+def change_backend(obj: T, new_backend: Backend, **backend_kwargs) -> T:
+    """Change the backend of a dataframe or a series."""
+    change_backend_functions = {
+        DaskDataFrame: _change_dataframe_backend_from_dask,
+        PandasDataFrame: _change_dataframe_backend_from_pandas,
+        PolarsDataFrame: _change_dataframe_backend_from_polars,
+        PyArrowDataFrame: _change_dataframe_backend_from_pyarrow,
+        DaskSeries: _change_series_backend_from_dask,
+        PandasSeries: _change_series_backend_from_pandas,
+        PolarsSeries: _change_series_backend_from_polars,
+        PyArrowSeries: _change_series_backend_from_pyarrow,
+    }
+
+    for supported_type, change_backend_function in change_backend_functions.items():
+        if isinstance(obj, supported_type):
+            return change_backend_function(obj, new_backend, **backend_kwargs)
+
+    raise TypeError(f"Unsupported type: {type(obj).__module__}.{type(obj).__qualname__}")
+
+
+def _change_dataframe_backend_from_dask(df: DaskDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
     """Change the backend of a Dask dataframe."""
     if new_backend == "dask":
         return df
@@ -55,7 +67,7 @@ def _change_backend_from_dask(df: DaskDataFrame, new_backend: Backend, **backend
     raise ValueError(f"Unsupported backend: {new_backend}")
 
 
-def _change_backend_from_pandas(df: PandasDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
+def _change_dataframe_backend_from_pandas(df: PandasDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
     """Change the backend of a Pandas dataframe."""
     if new_backend == "dask":
         return dd.from_pandas(df, **backend_kwargs)
@@ -72,7 +84,7 @@ def _change_backend_from_pandas(df: PandasDataFrame, new_backend: Backend, **bac
     raise ValueError(f"Unsupported backend: {new_backend}")
 
 
-def _change_backend_from_polars(df: PolarsDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
+def _change_dataframe_backend_from_polars(df: PolarsDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
     """Change the backend of a Polars dataframe."""
     if new_backend == "dask":
         return dd.from_pandas(df.to_pandas(use_pyarrow_extension_array=True), **backend_kwargs)
@@ -90,7 +102,7 @@ def _change_backend_from_polars(df: PolarsDataFrame, new_backend: Backend, **bac
     raise ValueError(f"Unsupported backend: {new_backend}")
 
 
-def _change_backend_from_pyarrow(df: PyArrowDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
+def _change_dataframe_backend_from_pyarrow(df: PyArrowDataFrame, new_backend: Backend, **backend_kwargs) -> DataFrame:
     """Change the backend of a PyArrow table."""
     if new_backend == "dask":
         return dd.from_pandas(df.to_pandas(types_mapper=pd.ArrowDtype), **backend_kwargs)
@@ -104,5 +116,76 @@ def _change_backend_from_pyarrow(df: PyArrowDataFrame, new_backend: Backend, **b
 
     if new_backend == "pyarrow":
         return df
+
+    raise ValueError(f"Unsupported backend: {new_backend}")
+
+
+def _change_series_backend_from_dask(series: dd.Series, new_backend: str, **backend_kwargs):
+    """Change the backend of a Dask series."""
+    if new_backend == "dask":
+        return series
+
+    if new_backend == "pandas":
+        return series.compute(**backend_kwargs)
+
+    if new_backend == "polars":
+        return pl.Series(series.compute(), **backend_kwargs)
+
+    if new_backend == "pyarrow":
+        return pa.Array.from_pandas(series.compute(), **backend_kwargs)
+
+    raise ValueError(f"Unsupported backend: {new_backend}")
+
+
+def _change_series_backend_from_pandas(series: pd.Series, new_backend: str, **backend_kwargs):
+    """Change the backend of a Pandas series."""
+    if new_backend == "dask":
+        return dd.from_pandas(series, **backend_kwargs)
+
+    if new_backend == "pandas":
+        return series
+
+    if new_backend == "polars":
+        return pl.from_pandas(series, **backend_kwargs)
+
+    if new_backend == "pyarrow":
+        return pa.Array.from_pandas(series)
+
+    raise ValueError(f"Unsupported backend: {new_backend}")
+
+
+def _change_series_backend_from_polars(series: pl.Series, new_backend: str, **backend_kwargs):
+    """Change the backend of a Polars series."""
+    if new_backend == "dask":
+        return dd.from_pandas(series.to_pandas(use_pyarrow_extension_array=True), **backend_kwargs)
+
+    if new_backend == "pandas":
+        backend_kwargs.setdefault("use_pyarrow_extension_array", True)
+        return series.to_pandas(**backend_kwargs)
+
+    if new_backend == "polars":
+        return series
+
+    if new_backend == "pyarrow":
+        return series.to_arrow(**backend_kwargs)
+
+    raise ValueError(f"Unsupported backend: {new_backend}")
+
+
+def _change_series_backend_from_pyarrow(series: pa.Array, new_backend: str, **backend_kwargs):
+    """Change the backend of a Pyarrow series."""
+    pandas_series = pd.Series(series.to_pandas())
+
+    if new_backend == "dask":
+        return dd.from_pandas(pandas_series, **backend_kwargs)
+
+    if new_backend == "pandas":
+        return pandas_series
+
+    if new_backend == "polars":
+        return pl.Series(pandas_series)
+
+    if new_backend == "pyarrow":
+        return series
 
     raise ValueError(f"Unsupported backend: {new_backend}")

--- a/tstore/backend.py
+++ b/tstore/backend.py
@@ -30,6 +30,23 @@ Series = Union[DaskSeries, PandasSeries, PolarsSeries, PyArrowSeries]
 T = TypeVar("T", DataFrame, Series)
 
 
+def get_backend(obj: T) -> Backend:
+    """Get the backend of a dataframe or a series."""
+    if isinstance(obj, (DaskDataFrame, DaskSeries)):
+        return "dask"
+
+    if isinstance(obj, (PandasDataFrame, PandasSeries)):
+        return "pandas"
+
+    if isinstance(obj, (PolarsDataFrame, PolarsSeries)):
+        return "polars"
+
+    if isinstance(obj, (PyArrowDataFrame, PyArrowSeries)):
+        return "pyarrow"
+
+    raise TypeError(f"Unsupported type: {type(obj).__module__}.{type(obj).__qualname__}")
+
+
 def change_backend(
     obj: T,
     new_backend: Backend,

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -290,6 +290,13 @@ def polars_long_dataframe(pandas_long_dataframe: pd.DataFrame) -> pl.DataFrame:
     return df_pl
 
 
+@pytest.fixture()
+def pyarrow_long_dataframe(pandas_long_dataframe: pd.DataFrame) -> pa.Table:
+    """Create a long Pyarrow Table."""
+    df_pa = pa.Table.from_pandas(pandas_long_dataframe, preserve_index=True)
+    return df_pa
+
+
 ## TSLong
 
 
@@ -324,6 +331,19 @@ def polars_tslong(polars_long_dataframe: pl.DataFrame) -> tstore.tslong.TSLongPo
     """Create a Polars TSLong object."""
     tslong = tstore.TSLong.wrap(
         polars_long_dataframe,
+        id_var=ID_VAR,
+        time_var=TIME_VAR,
+        ts_vars=TS_VARS,
+        static_vars=STATIC_VARS,
+    )
+    return tslong
+
+
+@pytest.fixture()
+def pyarrow_tslong(pyarrow_long_dataframe: pa.Table) -> tstore.tslong.TSLongPyArrow:
+    """Create a PyArrow TSLong object."""
+    tslong = tstore.TSLong.wrap(
+        pyarrow_long_dataframe,
         id_var=ID_VAR,
         time_var=TIME_VAR,
         ts_vars=TS_VARS,

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -47,6 +47,11 @@ class Helpers:
             seed=None,
         )
 
+        # TODO: Replace index by regular column
+        # df_dask = df_dask.reset_index()
+        # df_dask = df_dask.rename(columns={"index": TIME_VAR})
+
+        # Rename columns
         column_names = df_dask.columns
         new_column_names = [f"ts_var{i + 1}" for i in range(len(column_names))]
         df_dask = df_dask.rename(columns=dict(zip(column_names, new_column_names)))

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -3,12 +3,12 @@
 from pathlib import Path
 
 import dask
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
-from dask.dataframe import DataFrame as DaskDataFrame
 
 import tstore
 
@@ -56,13 +56,13 @@ def helpers() -> type[Helpers]:
 
 
 @pytest.fixture()
-def dask_dataframe(helpers) -> DaskDataFrame:
+def dask_dataframe(helpers) -> dd.DataFrame:
     """Create a Dask DataFrame with a dummy time series."""
     return helpers.create_dask_dataframe()
 
 
 @pytest.fixture()
-def pandas_dataframe(dask_dataframe: DaskDataFrame) -> pd.DataFrame:
+def pandas_dataframe(dask_dataframe: dd.DataFrame) -> pd.DataFrame:
     """Create a Pandas DataFrame with a dummy time series."""
     df_pd = dask_dataframe.compute()
     return df_pd
@@ -89,11 +89,42 @@ def pandas_dataframe_arrow_dtypes(pyarrow_dataframe: pa.Table) -> pd.DataFrame:
     return df_pd
 
 
+## Series
+
+
+@pytest.fixture()
+def pandas_series(pandas_dataframe: pd.DataFrame) -> pd.Series:
+    """Create a dummy Pandas Series of floats."""
+    series = pandas_dataframe["ts_var3"]
+    return series
+
+
+@pytest.fixture()
+def dask_series(pandas_series: pd.Series) -> dd.DataFrame:
+    """Create a Dask Series from a Pandas Series."""
+    series = dd.from_pandas(pandas_series)
+    return series
+
+
+@pytest.fixture()
+def polars_series(pandas_series: pd.Series) -> pl.Series:
+    """Create a Polars Series from a Pandas Series."""
+    series = pl.from_pandas(pandas_series)
+    return series
+
+
+@pytest.fixture()
+def pyarrow_series(pandas_series: pd.Series) -> pa.Array:
+    """Create a PyArrow Array from a Pandas Series."""
+    series = pa.Array.from_pandas(pandas_series)
+    return series
+
+
 ## Stored data
 
 
 @pytest.fixture()
-def parquet_timeseries(tmp_path: Path, dask_dataframe: DaskDataFrame) -> Path:
+def parquet_timeseries(tmp_path: Path, dask_dataframe: dd.DataFrame) -> Path:
     """Create a Parquet file with a dummy time series."""
     filepath = tmp_path / "test.parquet"
 

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -394,6 +394,5 @@ def dask_tsdf(helpers) -> tstore.tsdf.TSDFDask:
     tsdf = tstore.TSDF.wrap(
         df,
         id_var=ID_VAR,
-        time_var=TIME_VAR,
     )
     return tsdf

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -72,7 +72,7 @@ class Helpers:
 
         for _ in range(size):
             df = Helpers.create_dask_dataframe()
-            df = df.iloc[:, columns_slice].compute()
+            df = df.iloc[:, columns_slice]
             ts = tstore.TS(df)
             ts_list.append(ts)
 

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -302,5 +302,9 @@ def pandas_tsdf(pandas_series_of_ts: pd.Series) -> tstore.TSDF:
     df[ID_VAR] = [1, 2, 3, 4]
     df[ID_VAR] = df[ID_VAR].astype("large_string[pyarrow]")
 
-    tsdf = tstore.TSDF.wrap(df)
+    tsdf = tstore.TSDF.wrap(
+        df,
+        id_var=ID_VAR,
+        time_var=TIME_VAR,
+    )
     return tsdf

--- a/tstore/tests/conftest.py
+++ b/tstore/tests/conftest.py
@@ -274,7 +274,7 @@ def pandas_long_dataframe(helpers) -> pd.DataFrame:
 
     for store_id in store_ids:
         df = helpers.create_dask_dataframe().compute()
-        df[ID_VAR] = str(store_id)
+        df[ID_VAR] = store_id
         df[STATIC_VAR1] = chr(64 + store_id)  # A, B, C, D
         df[STATIC_VAR2] = float(store_id)  # 1.0, 2.0, 3.0, 4.0
         df_list.append(df)

--- a/tstore/tests/test_backend.py
+++ b/tstore/tests/test_backend.py
@@ -71,6 +71,7 @@ def test_change_dataframe_backend(
 
     # Check size
     assert df.shape[0] == df_new.shape[0]
+    print(backend_from, df.shape, backend_to, df_new.shape)
 
 
 @pytest.mark.parametrize("backend_to", backend_names)
@@ -118,8 +119,8 @@ def test_change_backend_to_and_fro(
 
 
 def test_polars_to_pandas(polars_dataframe: pl.DataFrame) -> None:
-    """Test the .to_pandas() method on a Polars DataFrame with PyArrow dtype."""
-    # Check that both methods return the same DataFrame
+    """Test the .to_pandas() method on a Polars DataFrame with PyArrow dtype using different kwargs."""
+    # Check that both kwargs return the same DataFrame
     df1 = polars_dataframe.to_pandas(use_pyarrow_extension_array=True)
     df2 = polars_dataframe.to_pandas(types_mapper=pd.ArrowDtype)
     pd.testing.assert_frame_equal(df1, df2)

--- a/tstore/tests/test_backend.py
+++ b/tstore/tests/test_backend.py
@@ -10,9 +10,13 @@ from tstore import backend
 
 # Fixtures imported from conftest.py:
 # - dask_dataframe
+# - dask_series
 # - pandas_dataframe
+# - pandas_series
 # - polars_dataframe
+# - polars_series
 # - pyarrow_dataframe
+# - pyarrow_series
 
 
 dataframe_types = {
@@ -22,30 +26,41 @@ dataframe_types = {
     "pyarrow": pa.Table,
 }
 
+series_types = {
+    "dask": dd.Series,
+    "pandas": pd.Series,
+    "polars": pl.Series,
+    "pyarrow": pa.Array,
+}
+
 backend_names = list(dataframe_types.keys())
 
 
 def test_types() -> None:
     """Test the types defined in the backend module."""
     assert backend.DaskDataFrame is dd.DataFrame
+    assert backend.DaskSeries is dd.Series
     assert backend.PandasDataFrame is pd.DataFrame
+    assert backend.PandasSeries is pd.Series
     assert backend.PolarsDataFrame is pl.DataFrame
+    assert backend.PolarsSeries is pl.Series
     assert backend.PyArrowDataFrame is pa.Table
+    assert backend.PyArrowSeries is pa.Array
 
 
 @pytest.mark.parametrize("backend_to", backend_names)
 @pytest.mark.parametrize("backend_from", backend_names)
-def test_change_backend(
+def test_change_dataframe_backend(
     backend_from: backend.Backend,
     backend_to: backend.Backend,
     request,
 ) -> None:
-    """Test the change_backend function."""
+    """Test the change_backend function on dataframes."""
     dataframe_fixture_name = f"{backend_from}_dataframe"
     df = request.getfixturevalue(dataframe_fixture_name)
     assert isinstance(df, dataframe_types[backend_from])
 
-    df_new = backend.change_backend(df=df, new_backend=backend_to)
+    df_new = backend.change_backend(obj=df, new_backend=backend_to)
     assert isinstance(df_new, dataframe_types[backend_to])
 
     if backend_from == "dask":
@@ -60,6 +75,25 @@ def test_change_backend(
 
 @pytest.mark.parametrize("backend_to", backend_names)
 @pytest.mark.parametrize("backend_from", backend_names)
+def test_change_series_backend(
+    backend_from: backend.Backend,
+    backend_to: backend.Backend,
+    request,
+) -> None:
+    """Test the change_backend function on series."""
+    series_fixture_name = f"{backend_from}_series"
+    series = request.getfixturevalue(series_fixture_name)
+    assert isinstance(series, series_types[backend_from])
+
+    series_new = backend.change_backend(obj=series, new_backend=backend_to)
+    assert isinstance(series_new, series_types[backend_to])
+
+    # Check size
+    assert len(series) == len(series_new)
+
+
+@pytest.mark.parametrize("backend_to", backend_names)
+@pytest.mark.parametrize("backend_from", backend_names)
 def test_change_backend_to_and_fro(
     backend_from: backend.Backend,
     backend_to: backend.Backend,
@@ -68,8 +102,8 @@ def test_change_backend_to_and_fro(
     """Test the change_backend function with A -> B -> A and check for equality."""
     dataframe_fixture_name = f"{backend_from}_dataframe"
     df = request.getfixturevalue(dataframe_fixture_name)
-    df_temp = backend.change_backend(df=df, new_backend=backend_to)
-    df_new = backend.change_backend(df=df_temp, new_backend=backend_from)
+    df_temp = backend.change_backend(obj=df, new_backend=backend_to)
+    df_new = backend.change_backend(obj=df_temp, new_backend=backend_from)
 
     if backend_from == "dask":
         df = df.compute()
@@ -81,3 +115,16 @@ def test_change_backend_to_and_fro(
     # Check values
     # TODO: Polars and PyArrow don't keep the index column
     assert df.equals(df_new)
+
+
+def test_polars_to_pandas(polars_dataframe: pl.DataFrame) -> None:
+    """Test the .to_pandas() method on a Polars DataFrame with PyArrow dtype."""
+    # Check that both methods return the same DataFrame
+    df1 = polars_dataframe.to_pandas(use_pyarrow_extension_array=True)
+    df2 = polars_dataframe.to_pandas(types_mapper=pd.ArrowDtype)
+    pd.testing.assert_frame_equal(df1, df2)
+
+    # Check that dtypes are ArrowDtypes
+    for df in [df1, df2]:
+        for dtype in df.dtypes:
+            assert isinstance(dtype, pd.ArrowDtype)

--- a/tstore/tests/test_backend.py
+++ b/tstore/tests/test_backend.py
@@ -103,8 +103,8 @@ def test_change_backend_to_and_fro(
     """Test the change_backend function with A -> B -> A and check for equality."""
     dataframe_fixture_name = f"{backend_from}_dataframe"
     df = request.getfixturevalue(dataframe_fixture_name)
-    df_temp = backend.change_backend(obj=df, new_backend=backend_to)
-    df_new = backend.change_backend(obj=df_temp, new_backend=backend_from)
+    df_temp = backend.change_backend(obj=df, new_backend=backend_to, index_var="time")
+    df_new = backend.change_backend(obj=df_temp, new_backend=backend_from, index_var="time")
 
     if backend_from == "dask":
         df = df.compute()
@@ -113,9 +113,11 @@ def test_change_backend_to_and_fro(
     # Check shape
     assert df.shape == df_new.shape
 
-    # Check values
-    # TODO: Polars and PyArrow don't keep the index column
-    assert df.equals(df_new)
+    # Check column names
+    if isinstance(df, pa.Table):
+        assert sorted(df.schema.names) == sorted(df_new.schema.names)
+    else:
+        assert sorted(df.columns) == sorted(df_new.columns)
 
 
 def test_polars_to_pandas(polars_dataframe: pl.DataFrame) -> None:

--- a/tstore/tests/test_ts.py
+++ b/tstore/tests/test_ts.py
@@ -84,16 +84,11 @@ class TestLoad:
         assert isinstance(ts._obj, pl.DataFrame)
 
 
-@pytest.mark.parametrize(
-    "type_check",
-    ["with_type_check", "no_type_check"],
-)
 class TestStoreAndLoad:
     """Test that the to_disk and from_disk methods of the TS class are consistent."""
 
     def test_dask(
         self,
-        type_check: str,
         dask_dataframe: dask.dataframe.DataFrame,
         tmp_path: Path,
     ) -> None:
@@ -106,18 +101,12 @@ class TestStoreAndLoad:
         df = ts._obj.compute()
         df_loaded = ts_loaded._obj.compute()
 
-        if type_check == "with_type_check":
-            # Test total equality
-            pd.testing.assert_frame_equal(df, df_loaded)
-
-        else:
-            # Test equality without matching types
-            # index is datetime or timestamp, strings are string or large_string
-            pd.testing.assert_frame_equal(df, df_loaded, check_dtype=False, check_index_type=False, check_freq=False)
+        # Test equality without matching types
+        # index is datetime or timestamp, strings are string or large_string
+        pd.testing.assert_frame_equal(df, df_loaded, check_dtype=False, check_index_type=False, check_freq=False)
 
     def test_pandas(
         self,
-        type_check: str,
         pandas_dataframe: pd.DataFrame,
         tmp_path: Path,
     ) -> None:
@@ -130,18 +119,12 @@ class TestStoreAndLoad:
         df = ts._obj
         df_loaded = ts_loaded._obj
 
-        if type_check == "with_type_check":
-            # Test total equality
-            pd.testing.assert_frame_equal(df, df_loaded)
-
-        else:
-            # Test equality without matching types
-            # index is datetime or timestamp, strings are string or large_string
-            pd.testing.assert_frame_equal(df, df_loaded, check_dtype=False, check_index_type=False, check_freq=False)
+        # Test equality without matching types
+        # index is datetime or timestamp, strings are string or large_string
+        pd.testing.assert_frame_equal(df, df_loaded, check_dtype=False, check_index_type=False, check_freq=False)
 
     def test_polars(
         self,
-        type_check: str,
         polars_dataframe: pl.DataFrame,
         tmp_path: Path,
     ) -> None:
@@ -154,10 +137,5 @@ class TestStoreAndLoad:
         df = ts._obj
         df_loaded = ts_loaded._obj
 
-        if type_check == "with_type_check":
-            # Test total equality
-            pl_testing.assert_frame_equal(df, df_loaded, check_column_order=False)
-
-        else:
-            # Test equality without matching types
-            pl_testing.assert_frame_equal(df, df_loaded, check_column_order=False, check_dtype=False)
+        # Test equality without matching types
+        pl_testing.assert_frame_equal(df, df_loaded, check_column_order=False)

--- a/tstore/tests/test_ts.py
+++ b/tstore/tests/test_ts.py
@@ -34,7 +34,7 @@ def test_wrap(
     df = request.getfixturevalue(dataframe_fixture_name)
     ts = TS(df)
 
-    assert dir(ts.data) == dir(df)
+    assert dir(ts._obj) == dir(df)
 
 
 @pytest.mark.parametrize(
@@ -64,7 +64,7 @@ class TestLoad:
     ) -> None:
         """Test on a Dask TS object."""
         ts = TS.from_file(parquet_timeseries, partitions=[])
-        assert isinstance(ts.data, dask.dataframe.DataFrame)
+        assert isinstance(ts._obj, dask.dataframe.DataFrame)
 
     def test_pandas(
         self,
@@ -100,8 +100,8 @@ class TestStoreAndLoad:
         ts.to_disk(filepath)
         ts_loaded = TS.from_file(filepath, partitions=[])
 
-        df = ts.data.compute()
-        df_loaded = ts_loaded.data.compute()
+        df = ts._obj.compute()
+        df_loaded = ts_loaded._obj.compute()
 
         if type_check == "with_type_check":
             # Test total equality
@@ -123,8 +123,8 @@ class TestStoreAndLoad:
         ts.to_disk(filepath)
         ts_loaded = TS.from_file(filepath, partitions=[])
 
-        df = ts.data.compute()
-        df_loaded = ts_loaded.data.compute()
+        df = ts._obj.compute()
+        df_loaded = ts_loaded._obj.compute()
 
         pd.testing.assert_frame_equal(df, df_loaded)
 
@@ -139,7 +139,7 @@ class TestStoreAndLoad:
         ts.to_disk(filepath)
         ts_loaded = TS.from_file(filepath, partitions=[])
 
-        df = ts.data.compute()
-        df_loaded = ts_loaded.data.compute()
+        df = ts._obj.compute()
+        df_loaded = ts_loaded._obj.compute()
 
         pd.testing.assert_frame_equal(df, df_loaded)

--- a/tstore/tests/test_ts.py
+++ b/tstore/tests/test_ts.py
@@ -36,6 +36,8 @@ def test_wrap(
     ts = TS(df)
 
     assert dir(ts._obj) == dir(df)
+    assert ts._tstore_time_var == "time"
+    assert ts.current_backend == dataframe_fixture_name.split("_")[0]
 
 
 @pytest.mark.parametrize(

--- a/tstore/tests/test_ts.py
+++ b/tstore/tests/test_ts.py
@@ -56,14 +56,14 @@ def test_store(
 
 
 class TestLoad:
-    """Test the from_file method of the TS class."""
+    """Test the from_disk method of the TS class."""
 
     def test_dask(
         self,
         parquet_timeseries: Path,
     ) -> None:
         """Test on a Dask TS object."""
-        ts = TS.from_file(parquet_timeseries, partitions=[])
+        ts = TS.from_disk(parquet_timeseries, partitions=[])
         assert isinstance(ts._obj, dask.dataframe.DataFrame)
 
     def test_pandas(
@@ -82,7 +82,7 @@ class TestLoad:
 
 
 class TestStoreAndLoad:
-    """Test that the to_disk and from_file methods of the TS class are consistent."""
+    """Test that the to_disk and from_disk methods of the TS class are consistent."""
 
     @pytest.mark.parametrize(
         "type_check",
@@ -98,7 +98,7 @@ class TestStoreAndLoad:
         filepath = str(tmp_path / "test.parquet")
         ts = TS(dask_dataframe)
         ts.to_disk(filepath)
-        ts_loaded = TS.from_file(filepath, partitions=[])
+        ts_loaded = TS.from_disk(filepath, partitions=[])
 
         df = ts._obj.compute()
         df_loaded = ts_loaded._obj.compute()
@@ -121,7 +121,7 @@ class TestStoreAndLoad:
         filepath = str(tmp_path / "test.parquet")
         ts = TS(pandas_dataframe)
         ts.to_disk(filepath)
-        ts_loaded = TS.from_file(filepath, partitions=[])
+        ts_loaded = TS.from_disk(filepath, partitions=[])
 
         df = ts._obj.compute()
         df_loaded = ts_loaded._obj.compute()
@@ -137,7 +137,7 @@ class TestStoreAndLoad:
         filepath = str(tmp_path / "test.parquet")
         ts = TS(polars_dataframe)
         ts.to_disk(filepath)
-        ts_loaded = TS.from_file(filepath, partitions=[])
+        ts_loaded = TS.from_disk(filepath, partitions=[])
 
         df = ts._obj.compute()
         df_loaded = ts_loaded._obj.compute()

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -44,18 +44,19 @@ def test_pandas_series_concatenation(pandas_series_of_ts: pd.Series) -> None:
 def test_pandas_tsdf_creation(pandas_tsdf: tstore.TSDF) -> None:
     """Test the TSDF wrapper."""
     assert isinstance(pandas_tsdf, tstore.TSDF)
-    assert isinstance(pandas_tsdf["ts_variable"], pd.Series)
+    assert isinstance(pandas_tsdf["ts_var1"], pd.Series)
+    assert isinstance(pandas_tsdf["ts_var2"], pd.Series)
     np.testing.assert_array_equal(pandas_tsdf["tstore_id"], ["1", "2", "3", "4"])
-    np.testing.assert_array_equal(pandas_tsdf["attribute_1"], ["A", "B", "C", "D"])
-    np.testing.assert_array_equal(pandas_tsdf["attribute_2"], [1.0, 2.0, 3.0, 4.0])
+    np.testing.assert_array_equal(pandas_tsdf["static_var1"], ["A", "B", "C", "D"])
+    np.testing.assert_array_equal(pandas_tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])
 
 
 def test_attributes(pandas_tsdf: tstore.TSDF) -> None:
     """Test the given and computed _tstore_ attributes."""
     assert pandas_tsdf._tstore_id_var == "tstore_id"
     assert pandas_tsdf._tstore_time_var == "time"
-    assert pandas_tsdf._tstore_ts_vars == {"ts_variable": ["ts_var1", "ts_var2", "ts_var3", "ts_var4"]}
-    assert pandas_tsdf._tstore_static_vars == ["attribute_1", "attribute_2"]
+    assert pandas_tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
+    assert pandas_tsdf._tstore_static_vars == ["static_var1", "static_var2"]
 
 
 def test_add(
@@ -71,8 +72,8 @@ def test_add(
 
 def test_drop(pandas_tsdf: tstore.TSDF) -> None:
     """Test dropping a variable."""
-    pandas_tsdf = pandas_tsdf.drop(columns=["ts_variable"])
-    assert "ts_variable" not in pandas_tsdf.columns
+    pandas_tsdf = pandas_tsdf.drop(columns=["ts_var1"])
+    assert "ts_var1" not in pandas_tsdf.columns
     assert isinstance(pandas_tsdf, tstore.TSDF)
 
 
@@ -102,7 +103,7 @@ def test_store(
     assert dirpath.is_dir()
 
     # Check directory content
-    assert sorted(os.listdir(dirpath / "1" / "ts_variable")) == [
+    assert sorted(os.listdir(dirpath / "1" / "ts_var1")) == [
         "_common_metadata",
         "_metadata",
         "part.0.parquet",
@@ -122,4 +123,13 @@ class TestLoad:
         tsdf = tstore.open_tsdf(tstore_path, backend="pandas")
         assert type(tsdf) is TSDFPandas
         assert type(tsdf._obj) is pd.DataFrame
-        assert tsdf.shape == (4, 2)
+        assert tsdf._tstore_id_var == "tstore_id"
+        assert tsdf._tstore_time_var == "time"
+        assert tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
+        assert tsdf._tstore_static_vars == ["static_var1", "static_var2"]
+        assert isinstance(tsdf["ts_var1"], pd.Series)
+        assert isinstance(tsdf["ts_var2"], pd.Series)
+        # TODO: add tstore_id column instead of using an index
+        # np.testing.assert_array_equal(tsdf["tstore_id"], ["1", "2", "3", "4"])
+        np.testing.assert_array_equal(tsdf["static_var1"], ["A", "B", "C", "D"])
+        np.testing.assert_array_equal(tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -7,19 +7,19 @@ import numpy as np
 import pandas as pd
 
 import tstore
-from tstore.tsdf.pandas import TSDFPandas
+from tstore.tsdf.dask import TSDFDask
 
 # Imported fixtures from conftest.py:
-# - pandas_tsarray
+# - dask_tsarray
 # - pandas_series_of_ts
-# - pandas_tsdf
+# - dask_tsdf
 
 
-def test_tsarray_creation(pandas_tsarray: tstore.TSArray) -> None:
+def test_tsarray_creation(dask_tsarray: tstore.TSArray) -> None:
     """Test the TSArray wrapper."""
-    assert isinstance(pandas_tsarray, tstore.TSArray)
-    assert pandas_tsarray.shape == (4,)
-    assert isinstance(pandas_tsarray[0], tstore.TS)
+    assert isinstance(dask_tsarray, tstore.TSArray)
+    assert dask_tsarray.shape == (4,)
+    assert isinstance(dask_tsarray[0], tstore.TS)
 
 
 def test_pandas_series_of_ts_creation(pandas_series_of_ts: pd.Series) -> None:
@@ -41,50 +41,50 @@ def test_pandas_series_concatenation(pandas_series_of_ts: pd.Series) -> None:
     assert isinstance(df_series.dtype, tstore.TSDtype)
 
 
-def test_pandas_tsdf_creation(pandas_tsdf: tstore.TSDF) -> None:
+def test_dask_tsdf_creation(dask_tsdf: tstore.TSDF) -> None:
     """Test the TSDF wrapper."""
-    assert isinstance(pandas_tsdf, tstore.TSDF)
-    assert isinstance(pandas_tsdf["ts_var1"], pd.Series)
-    assert isinstance(pandas_tsdf["ts_var2"], pd.Series)
-    np.testing.assert_array_equal(pandas_tsdf["tstore_id"], ["1", "2", "3", "4"])
-    np.testing.assert_array_equal(pandas_tsdf["static_var1"], ["A", "B", "C", "D"])
-    np.testing.assert_array_equal(pandas_tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])
+    assert isinstance(dask_tsdf, tstore.TSDF)
+    assert isinstance(dask_tsdf["ts_var1"], pd.Series)
+    assert isinstance(dask_tsdf["ts_var2"], pd.Series)
+    np.testing.assert_array_equal(dask_tsdf["tstore_id"], ["1", "2", "3", "4"])
+    np.testing.assert_array_equal(dask_tsdf["static_var1"], ["A", "B", "C", "D"])
+    np.testing.assert_array_equal(dask_tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])
 
 
-def test_attributes(pandas_tsdf: tstore.TSDF) -> None:
+def test_attributes(dask_tsdf: tstore.TSDF) -> None:
     """Test the given and computed _tstore_ attributes."""
-    assert pandas_tsdf._tstore_id_var == "tstore_id"
-    assert pandas_tsdf._tstore_time_var == "time"
-    assert pandas_tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
-    assert pandas_tsdf._tstore_static_vars == ["static_var1", "static_var2"]
+    assert dask_tsdf._tstore_id_var == "tstore_id"
+    assert dask_tsdf._tstore_time_var == "time"
+    assert dask_tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
+    assert dask_tsdf._tstore_static_vars == ["static_var1", "static_var2"]
 
 
 def test_add(
     pandas_series_of_ts: pd.Series,
-    pandas_tsdf: tstore.TSDF,
+    dask_tsdf: tstore.TSDF,
 ) -> None:
     """Test adding a Pandas Series to a TSDF."""
-    pandas_tsdf["new_variable"] = pandas_series_of_ts
-    assert "new_variable" in pandas_tsdf.columns
-    assert isinstance(pandas_tsdf, tstore.TSDF)
-    assert isinstance(pandas_tsdf["new_variable"], pd.Series)
+    dask_tsdf["new_variable"] = pandas_series_of_ts
+    assert "new_variable" in dask_tsdf.columns
+    assert isinstance(dask_tsdf, tstore.TSDF)
+    assert isinstance(dask_tsdf["new_variable"], pd.Series)
 
 
-def test_drop(pandas_tsdf: tstore.TSDF) -> None:
+def test_drop(dask_tsdf: tstore.TSDF) -> None:
     """Test dropping a variable."""
-    pandas_tsdf = pandas_tsdf.drop(columns=["ts_var1"])
-    assert "ts_var1" not in pandas_tsdf.columns
-    assert isinstance(pandas_tsdf, tstore.TSDF)
+    dask_tsdf = dask_tsdf.drop(columns=["ts_var1"])
+    assert "ts_var1" not in dask_tsdf.columns
+    assert isinstance(dask_tsdf, tstore.TSDF)
 
 
-def test_iloc(pandas_tsdf: tstore.TSDF) -> None:
+def test_iloc(dask_tsdf: tstore.TSDF) -> None:
     """Test subsetting a Pandas TSDF with iloc."""
-    tsdf = pandas_tsdf.iloc[0:10]
+    tsdf = dask_tsdf.iloc[0:10]
     assert isinstance(tsdf, tstore.TSDF)
 
 
 def test_store(
-    pandas_tsdf: tstore.TSDF,
+    dask_tsdf: tstore.TSDF,
     tmp_path,
 ) -> None:
     """Test the to_store method."""
@@ -92,7 +92,7 @@ def test_store(
     partitioning = None
     tstore_structure = "id-var"
     overwrite = True
-    pandas_tsdf.to_tstore(
+    dask_tsdf.to_tstore(
         str(dirpath),
         partitioning=partitioning,
         tstore_structure=tstore_structure,
@@ -108,7 +108,6 @@ def test_store(
             "_common_metadata",
             "_metadata",
             "part.0.parquet",
-            "part.1.parquet",
         ]
     assert sorted(os.listdir(dirpath)) == ["1", "2", "3", "4", "_attributes.parquet", "tstore_metadata.yaml"]
 
@@ -116,13 +115,13 @@ def test_store(
 class TestLoad:
     """Test the from_tstore function."""
 
-    def test_pandas(
+    def test_dask(
         self,
         tstore_path: Path,
     ) -> None:
-        """Test loading as a Pandas TSDF."""
-        tsdf = tstore.open_tsdf(tstore_path, backend="pandas")
-        assert type(tsdf) is TSDFPandas
+        """Test loading as a Dask TSDF."""
+        tsdf = tstore.open_tsdf(tstore_path, backend="dask")
+        assert type(tsdf) is TSDFDask
         assert type(tsdf._obj) is pd.DataFrame
         assert tsdf._tstore_id_var == "tstore_id"
         assert tsdf._tstore_time_var == "time"

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -54,7 +54,6 @@ def test_dask_tsdf_creation(dask_tsdf: tstore.TSDF) -> None:
 def test_attributes(dask_tsdf: tstore.TSDF) -> None:
     """Test the given and computed _tstore_ attributes."""
     assert dask_tsdf._tstore_id_var == "tstore_id"
-    assert dask_tsdf._tstore_time_var == "time"
     assert dask_tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
     assert dask_tsdf._tstore_static_vars == ["static_var1", "static_var2"]
 
@@ -124,12 +123,10 @@ class TestLoad:
         assert type(tsdf) is TSDFDask
         assert type(tsdf._obj) is pd.DataFrame
         assert tsdf._tstore_id_var == "tstore_id"
-        assert tsdf._tstore_time_var == "time"
         assert tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
         assert tsdf._tstore_static_vars == ["static_var1", "static_var2"]
         assert isinstance(tsdf["ts_var1"], pd.Series)
         assert isinstance(tsdf["ts_var2"], pd.Series)
-        # TODO: add tstore_id column instead of using an index
-        # np.testing.assert_array_equal(tsdf["tstore_id"], ["1", "2", "3", "4"])
+        np.testing.assert_array_equal(tsdf["tstore_id"], ["1", "2", "3", "4"])
         np.testing.assert_array_equal(tsdf["static_var1"], ["A", "B", "C", "D"])
         np.testing.assert_array_equal(tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -103,12 +103,13 @@ def test_store(
     assert dirpath.is_dir()
 
     # Check directory content
-    assert sorted(os.listdir(dirpath / "1" / "ts_var1")) == [
-        "_common_metadata",
-        "_metadata",
-        "part.0.parquet",
-        "part.1.parquet",
-    ]
+    for ts_var in ["ts_var1", "ts_var2"]:
+        assert sorted(os.listdir(dirpath / "1" / ts_var)) == [
+            "_common_metadata",
+            "_metadata",
+            "part.0.parquet",
+            "part.1.parquet",
+        ]
     assert sorted(os.listdir(dirpath)) == ["1", "2", "3", "4", "_attributes.parquet", "tstore_metadata.yaml"]
 
 

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -50,6 +50,15 @@ def test_pandas_tsdf_creation(pandas_tsdf: tstore.TSDF) -> None:
     np.testing.assert_array_equal(pandas_tsdf["attribute_2"], [1.0, 2.0, 3.0, 4.0])
 
 
+def test_attributes(pandas_tsdf: tstore.TSDF) -> None:
+    """Test the given and computed _tstore_ attributes."""
+    breakpoint()
+    assert pandas_tsdf._tstore_id_var == "tstore_id"
+    assert pandas_tsdf._tstore_time_var == "time"
+    assert pandas_tsdf._tstore_ts_vars == {"ts_variable": ["ts_variable"]}
+    assert pandas_tsdf._tstore_static_vars == ["attribute_1", "attribute_2"]
+
+
 def test_add(
     pandas_series_of_ts: pd.Series,
     pandas_tsdf: tstore.TSDF,

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -46,6 +46,7 @@ def test_pandas_series_concatenation(pandas_series_of_ts: pd.Series) -> None:
 def test_dask_tsdf_creation(dask_tsdf: tstore.TSDF) -> None:
     """Test the TSDF wrapper."""
     assert isinstance(dask_tsdf, tstore.TSDF)
+    assert dask_tsdf.current_backend == "dask"
     assert isinstance(dask_tsdf["ts_var1"], pd.Series)
     assert isinstance(dask_tsdf["ts_var2"], pd.Series)
     np.testing.assert_array_equal(dask_tsdf["tstore_id"], ["1", "2", "3", "4"])

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -176,7 +176,8 @@ def test_change_backend(
     np.testing.assert_array_equal(tsdf_new["static_var2"], [1.0, 2.0, 3.0, 4.0])
 
 
-@pytest.mark.parametrize("backend", ["dask", "pandas", "polars", "pyarrow"])
+# @pytest.mark.parametrize("backend", ["dask", "pandas", "polars", "pyarrow"])
+@pytest.mark.parametrize("backend", ["polars", "pyarrow"])
 def test_to_tslong(
     backend: Backend,
     dask_tsdf: tstore.TSDF,

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -85,8 +85,6 @@ def test_store(
     overwrite = True
     pandas_tsdf.to_tstore(
         str(dirpath),
-        id_var="tstore_id",
-        time_var="time",
         partitioning=partitioning,
         tstore_structure=tstore_structure,
         overwrite=overwrite,

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -52,10 +52,9 @@ def test_pandas_tsdf_creation(pandas_tsdf: tstore.TSDF) -> None:
 
 def test_attributes(pandas_tsdf: tstore.TSDF) -> None:
     """Test the given and computed _tstore_ attributes."""
-    breakpoint()
     assert pandas_tsdf._tstore_id_var == "tstore_id"
     assert pandas_tsdf._tstore_time_var == "time"
-    assert pandas_tsdf._tstore_ts_vars == {"ts_variable": ["ts_variable"]}
+    assert pandas_tsdf._tstore_ts_vars == {"ts_variable": ["ts_var1", "ts_var2", "ts_var3", "ts_var4"]}
     assert pandas_tsdf._tstore_static_vars == ["attribute_1", "attribute_2"]
 
 

--- a/tstore/tests/test_tsdf.py
+++ b/tstore/tests/test_tsdf.py
@@ -115,5 +115,5 @@ class TestLoad:
         """Test loading as a Pandas TSDF."""
         tsdf = tstore.open_tsdf(tstore_path, backend="pandas")
         assert type(tsdf) is TSDFPandas
-        assert type(tsdf._df) is pd.DataFrame
-        assert tsdf.shape == (4, 3)
+        assert type(tsdf._obj) is pd.DataFrame
+        assert tsdf.shape == (4, 2)

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -23,6 +23,8 @@ from tstore.tslong.pyarrow import TSLongPyArrow
 # - pandas_tslong
 # - polars_long_dataframe
 # - polars_tslong
+# - pyarrow_long_dataframe
+# - pyarrow_tslong
 
 
 tslong_classes = {
@@ -59,7 +61,7 @@ def store_tslong(tslong: tstore.TSLong, dirpath: str) -> None:
 # Tests ########################################################################
 
 
-@pytest.mark.parametrize("backend", ["dask", "pandas", "polars"])
+@pytest.mark.parametrize("backend", ["dask", "pandas", "polars", "pyarrow"])
 def test_creation(
     backend: Backend,
     request,
@@ -91,6 +93,7 @@ def test_creation(
         "dask_tslong",
         "pandas_tslong",
         "polars_tslong",
+        "pyarrow_tslong",
     ],
 )
 def test_store(
@@ -173,7 +176,7 @@ class TestLoad:
 
 
 @pytest.mark.parametrize("backend_to", ["dask", "pandas", "polars", "pyarrow"])
-@pytest.mark.parametrize("backend_from", ["dask", "pandas", "polars"])
+@pytest.mark.parametrize("backend_from", ["dask", "pandas", "polars", "pyarrow"])
 def test_change_backend(
     backend_from: Backend,
     backend_to: Backend,

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -101,7 +101,8 @@ def test_store(
 
     # Check directory content
     assert sorted(os.listdir(dirpath)) == ["1", "2", "3", "4", "_attributes.parquet", "tstore_metadata.yaml"]
-    assert os.listdir(dirpath / "1" / "ts_var1" / "year=2000" / "month=1") == ["part-0.parquet"]
+    for ts_var in ["ts_var1", "ts_var2"]:
+        assert os.listdir(dirpath / "1" / ts_var / "year=2000" / "month=1") == ["part-0.parquet"]
 
 
 class TestLoad:

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -212,7 +212,7 @@ def test_change_backend(
     assert isinstance(tslong_new, tslong_classes[backend_to])
 
 
-@pytest.mark.parametrize("backend", ["dask", "pandas"])
+@pytest.mark.parametrize("backend", ["dask", "pandas", "polars", "pyarrow"])
 def test_to_tsdf(
     backend: str,
     request,

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -109,7 +109,7 @@ class TestLoad:
     """Test the from_tstore function."""
 
     def common_checks(self, tslong: tstore.TSLong) -> None:
-        assert tslong.shape == (192, 8)
+        assert tslong.shape[0] == 192
         assert tslong._tstore_id_var == "tstore_id"
         assert tslong._tstore_time_var == "time"
         assert tslong._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -217,7 +217,6 @@ def test_to_tsdf(
 
     assert isinstance(tsdf, tstore.TSDF)
     assert tsdf._tstore_id_var == "tstore_id"
-    assert tsdf._tstore_time_var == "time"
     assert tsdf._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
     assert tsdf._tstore_static_vars == ["static_var1", "static_var2"]
     assert isinstance(tsdf["ts_var1"], pd.Series)

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -115,7 +115,7 @@ class TestLoad:
         """Test loading as a Pandas DataFrame."""
         tslong = tstore.open_tslong(tstore_path, backend="pandas", ts_variables=["ts_variable"])
         assert type(tslong) is TSLongPandas
-        assert type(tslong._df) is pd.DataFrame
+        assert type(tslong._obj) is pd.DataFrame
         assert tslong.shape == (192, 7)
         # TODO: dataframe should be wrapped in a TSLong object
         # TODO: time column is counted
@@ -129,7 +129,7 @@ class TestLoad:
         """Test loading as a Polars DataFrame."""
         tslong = tstore.open_tslong(tstore_path, backend="polars", ts_variables=["ts_variable"])
         assert type(tslong) is TSLongPolars
-        assert type(tslong._df) is pl.DataFrame
+        assert type(tslong._obj) is pl.DataFrame
         assert tslong.shape == (192, 7)
         # TODO: dataframe should be wrapped in a TSLong object
         # TODO: time column is counted
@@ -143,7 +143,7 @@ class TestLoad:
         """Test loading as a PyArrow Table."""
         tslong = tstore.open_tslong(tstore_path, backend="polars", ts_variables=["ts_variable"])
         assert type(tslong) is TSLongPolars
-        assert type(tslong._df) is pl.DataFrame
+        assert type(tslong._obj) is pl.DataFrame
         assert tslong.shape == (192, 7)
 
 

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -120,7 +120,6 @@ class TestLoad:
     ) -> None:
         """Test loading as a Pandas DataFrame."""
         tslong = tstore.open_tslong(tstore_path, backend="pandas", ts_variables=["ts_var1", "ts_var2"])
-        breakpoint()
         assert type(tslong) is TSLongPandas
         assert type(tslong._obj) is pd.DataFrame
         self.common_checks(tslong)

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -20,6 +20,10 @@ from tstore.tslong.dask import TSLongDask
 from tstore.tslong.pandas import TSLongPandas
 from tstore.tslong.polars import TSLongPolars
 from tstore.tslong.pyarrow import TSLongPyArrow
+from tstore.tswide.dask import TSWideDask
+from tstore.tswide.pandas import TSWidePandas
+from tstore.tswide.polars import TSWidePolars
+from tstore.tswide.pyarrow import TSWidePyArrow
 
 # Imported fixtures from conftest.py:
 # - dask_long_dataframe
@@ -44,6 +48,13 @@ tsdf_classes = {
     "pandas": TSDFPandas,
     "polars": TSDFPolars,
     "pyarrow": TSDFPyArrow,
+}
+
+tswide_classes = {
+    "dask": TSWideDask,
+    "pandas": TSWidePandas,
+    "polars": TSWidePolars,
+    "pyarrow": TSWidePyArrow,
 }
 
 
@@ -231,3 +242,20 @@ def test_to_tsdf(
     np.testing.assert_array_equal(tsdf["tstore_id"], ["1", "2", "3", "4"])
     np.testing.assert_array_equal(tsdf["static_var1"], ["A", "B", "C", "D"])
     np.testing.assert_array_equal(tsdf["static_var2"], [1.0, 2.0, 3.0, 4.0])
+
+
+@pytest.mark.parametrize("backend", ["dask", "pandas", "polars", "pyarrow"])
+def test_to_tswide(
+    backend: str,
+    request,
+) -> None:
+    """Test the to_tsdf function."""
+    tslong_fixture_name = f"{backend}_tslong"
+    tslong = request.getfixturevalue(tslong_fixture_name)
+    tswide = tslong.to_tswide()
+
+    assert isinstance(tswide, tswide_classes[backend])
+    assert tswide._tstore_id_var == "tstore_id"
+    assert tswide._tstore_time_var == "time"
+    assert tswide._tstore_ts_vars == {"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]}
+    assert tswide._tstore_static_vars == ["static_var1", "static_var2"]

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -90,6 +90,7 @@ def test_creation(
     )
 
     assert isinstance(tslong, tslong_classes[backend])
+    assert tslong.current_backend == backend
 
     if isinstance(tslong, TSLongDask):
         assert tslong._obj.compute().shape == df.compute().shape

--- a/tstore/tests/test_tslong.py
+++ b/tstore/tests/test_tslong.py
@@ -67,9 +67,14 @@ def test_creation(
         df,
         id_var="tstore_id",
         time_var="time",
+        static_vars=["static_var"],
     )
     assert isinstance(tslong, tslong_classes[backend])
     assert tslong.shape == df.shape
+    assert tslong._tstore_id_var == "tstore_id"
+    assert tslong._tstore_time_var == "time"
+    assert tslong._tstore_ts_vars == {"ts_variable": ["ts_var1", "ts_var2", "ts_var3", "ts_var4"]}
+    assert tslong._tstore_static_vars == ["static_var"]
 
 
 @pytest.mark.parametrize(

--- a/tstore/tsdf/__init__.py
+++ b/tstore/tsdf/__init__.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from typing import Union
 
 from tstore.backend import Backend
-from tstore.tsdf.pandas import TSDFPandas
+from tstore.tsdf.dask import TSDFDask
 from tstore.tsdf.tsdf import TSDF
 
 
-def open_tsdf(base_dir: Union[str, Path], *args, backend: Backend = "pandas", **kwargs):
+def open_tsdf(base_dir: Union[str, Path], *args, backend: Backend = "dask", **kwargs):
     """Read a TStore file structure as a TSDF object."""
     tsdf_classes = {
-        "pandas": TSDFPandas,
+        "dask": TSDFDask,
     }
 
     if backend not in tsdf_classes:

--- a/tstore/tsdf/dask.py
+++ b/tstore/tsdf/dask.py
@@ -1,0 +1,26 @@
+"""TSDF class wrapping a Dask dataframe of TSArray objects."""
+
+from typing import TYPE_CHECKING
+
+from tstore.tsdf.tsdf import TSDF
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.dask import TSLongDask
+
+
+class TSDFDask(TSDF):
+    """A dataframe class with additional functionality for TSArray data."""
+
+    def to_tstore(self):
+        """Write TStore from TSDF object."""
+        raise NotImplementedError
+
+    @staticmethod
+    def from_tstore(base_dir: str) -> "TSDFDask":
+        """Read TStore into TSDF object."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongDask":
+        """Convert the wrapper into a TSLong object."""
+        raise NotImplementedError

--- a/tstore/tsdf/dask.py
+++ b/tstore/tsdf/dask.py
@@ -2,7 +2,10 @@
 
 from typing import TYPE_CHECKING
 
+from tstore.archive.metadata.readers import read_tstore_metadata
+from tstore.tsdf.reader import _read_tsarrays
 from tstore.tsdf.tsdf import TSDF
+from tstore.tsdf.writer import write_tstore
 
 if TYPE_CHECKING:
     # To avoid circular imports
@@ -12,14 +15,64 @@ if TYPE_CHECKING:
 class TSDFDask(TSDF):
     """A dataframe class with additional functionality for TSArray data."""
 
-    def to_tstore(self):
+    def to_tstore(
+        self,
+        base_dir,
+        partitioning=None,
+        tstore_structure="id-var",
+        overwrite=True,  # append functionality?
+        # geometry
+    ):
         """Write TStore from TSDF object."""
-        raise NotImplementedError
+        _ = write_tstore(
+            self._obj,
+            base_dir=base_dir,
+            id_var=self._tstore_id_var,
+            time_var=self._tstore_time_var,
+            partitioning=partitioning,
+            tstore_structure=tstore_structure,
+            overwrite=overwrite,
+        )
 
     @staticmethod
     def from_tstore(base_dir: str) -> "TSDFDask":
         """Read TStore into TSDF object."""
-        raise NotImplementedError
+        # TODO: enable specify subset of TSArrays, attribute columns and rows to load
+        # TODO: read_attributes using geopandas --> geoparquet
+        # TODO: separate TSDF class if geoparquet (TSDF inherit from geopandas.GeoDataFrame ?)
+        from tstore.archive.attributes.pandas import read_attributes
+
+        # Read TStore metadata
+        metadata = read_tstore_metadata(base_dir=base_dir)
+
+        # Read TStore attributes
+        df = read_attributes(base_dir).set_index(metadata["id_var"])
+
+        # Get list of TSArrays
+        list_ts_series = _read_tsarrays(base_dir, metadata)
+
+        # Join TSArrays to dataframe
+        for ts_series in list_ts_series:
+            df = df.join(ts_series, how="left")
+            #  pd.merge(df_attrs, df_series, left_index=True, right_index=True)
+
+        # Return the TSDF
+        return TSDFDask(
+            df,
+            id_var=metadata["id_var"],
+            time_var=metadata["time_var"],
+        )
+
+    # Method that return identifier column
+
+    # Method that return the timeseries columns  (TSArrays)
+
+    # Add compute method
+
+    # Add wrappers to methods iloc, loc or join to return TSDF class
+
+    # Remove methods that are not supported by TSArray
+    # --> min, ...
 
     def to_tslong(self) -> "TSLongDask":
         """Convert the wrapper into a TSLong object."""

--- a/tstore/tsdf/dask.py
+++ b/tstore/tsdf/dask.py
@@ -28,7 +28,6 @@ class TSDFDask(TSDF):
             self._obj,
             base_dir=base_dir,
             id_var=self._tstore_id_var,
-            time_var=self._tstore_time_var,
             partitioning=partitioning,
             tstore_structure=tstore_structure,
             overwrite=overwrite,
@@ -60,7 +59,6 @@ class TSDFDask(TSDF):
         return TSDFDask(
             df,
             id_var=metadata["id_var"],
-            time_var=metadata["time_var"],
         )
 
     # Method that return identifier column

--- a/tstore/tsdf/pandas.py
+++ b/tstore/tsdf/pandas.py
@@ -21,7 +21,7 @@ class TSDFPandas(TSDF):
     ):
         """Write TStore from TSDF object."""
         _ = write_tstore(
-            self._df,
+            self._obj,
             base_dir=base_dir,
             id_var=id_var,
             time_var=time_var,

--- a/tstore/tsdf/pandas.py
+++ b/tstore/tsdf/pandas.py
@@ -6,7 +6,7 @@ from tstore.tsdf.tsdf import TSDF
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tslong.pandas import TSLongPandas
+    pass
 
 
 class TSDFPandas(TSDF):
@@ -19,8 +19,4 @@ class TSDFPandas(TSDF):
     @staticmethod
     def from_tstore(base_dir: str) -> "TSDFPandas":
         """Read TStore into TSDF object."""
-        raise NotImplementedError
-
-    def to_tslong(self) -> "TSLongPandas":
-        """Convert the wrapper into a TSLong object."""
         raise NotImplementedError

--- a/tstore/tsdf/pandas.py
+++ b/tstore/tsdf/pandas.py
@@ -1,9 +1,15 @@
 """TSDF class wrapping a Pandas dataframe of TSArray objects."""
 
+from typing import TYPE_CHECKING
+
 from tstore.archive.metadata.readers import read_tstore_metadata
 from tstore.tsdf.reader import _read_tsarrays
 from tstore.tsdf.tsdf import TSDF
 from tstore.tsdf.writer import write_tstore
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.pandas import TSLongPandas
 
 
 class TSDFPandas(TSDF):
@@ -67,3 +73,7 @@ class TSDFPandas(TSDF):
 
     # Remove methods that are not supported by TSArray
     # --> min, ...
+
+    def to_tslong(self) -> "TSLongPandas":
+        """Convert the wrapper into a TSLong object."""
+        raise NotImplementedError

--- a/tstore/tsdf/pandas.py
+++ b/tstore/tsdf/pandas.py
@@ -2,10 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from tstore.archive.metadata.readers import read_tstore_metadata
-from tstore.tsdf.reader import _read_tsarrays
 from tstore.tsdf.tsdf import TSDF
-from tstore.tsdf.writer import write_tstore
 
 if TYPE_CHECKING:
     # To avoid circular imports
@@ -15,64 +12,14 @@ if TYPE_CHECKING:
 class TSDFPandas(TSDF):
     """A dataframe class with additional functionality for TSArray data."""
 
-    def to_tstore(
-        self,
-        base_dir,
-        partitioning=None,
-        tstore_structure="id-var",
-        overwrite=True,  # append functionality?
-        # geometry
-    ):
+    def to_tstore(self):
         """Write TStore from TSDF object."""
-        _ = write_tstore(
-            self._obj,
-            base_dir=base_dir,
-            id_var=self._tstore_id_var,
-            time_var=self._tstore_time_var,
-            partitioning=partitioning,
-            tstore_structure=tstore_structure,
-            overwrite=overwrite,
-        )
+        raise NotImplementedError
 
     @staticmethod
     def from_tstore(base_dir: str) -> "TSDFPandas":
         """Read TStore into TSDF object."""
-        # TODO: enable specify subset of TSArrays, attribute columns and rows to load
-        # TODO: read_attributes using geopandas --> geoparquet
-        # TODO: separate TSDF class if geoparquet (TSDF inherit from geopandas.GeoDataFrame ?)
-        from tstore.archive.attributes.pandas import read_attributes
-
-        # Read TStore metadata
-        metadata = read_tstore_metadata(base_dir=base_dir)
-
-        # Read TStore attributes
-        df = read_attributes(base_dir).set_index(metadata["id_var"])
-
-        # Get list of TSArrays
-        list_ts_series = _read_tsarrays(base_dir, metadata)
-
-        # Join TSArrays to dataframe
-        for ts_series in list_ts_series:
-            df = df.join(ts_series, how="left")
-            #  pd.merge(df_attrs, df_series, left_index=True, right_index=True)
-
-        # Return the TSDF
-        return TSDFPandas(
-            df,
-            id_var=metadata["id_var"],
-            time_var=metadata["time_var"],
-        )
-
-    # Method that return identifier column
-
-    # Method that return the timeseries columns  (TSArrays)
-
-    # Add compute method
-
-    # Add wrappers to methods iloc, loc or join to return TSDF class
-
-    # Remove methods that are not supported by TSArray
-    # --> min, ...
+        raise NotImplementedError
 
     def to_tslong(self) -> "TSLongPandas":
         """Convert the wrapper into a TSLong object."""

--- a/tstore/tsdf/pandas.py
+++ b/tstore/tsdf/pandas.py
@@ -12,8 +12,6 @@ class TSDFPandas(TSDF):
     def to_tstore(
         self,
         base_dir,
-        id_var,
-        time_var,  # likely not needed !
         partitioning=None,
         tstore_structure="id-var",
         overwrite=True,  # append functionality?
@@ -23,8 +21,8 @@ class TSDFPandas(TSDF):
         _ = write_tstore(
             self._obj,
             base_dir=base_dir,
-            id_var=id_var,
-            time_var=time_var,
+            id_var=self._tstore_id_var,
+            time_var=self._tstore_time_var,
             partitioning=partitioning,
             tstore_structure=tstore_structure,
             overwrite=overwrite,
@@ -53,7 +51,11 @@ class TSDFPandas(TSDF):
             #  pd.merge(df_attrs, df_series, left_index=True, right_index=True)
 
         # Return the TSDF
-        return TSDFPandas(df)
+        return TSDFPandas(
+            df,
+            id_var=metadata["id_var"],
+            time_var=metadata["time_var"],
+        )
 
     # Method that return identifier column
 

--- a/tstore/tsdf/polars.py
+++ b/tstore/tsdf/polars.py
@@ -6,7 +6,7 @@ from tstore.tsdf.tsdf import TSDF
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tslong.polars import TSLongPolars
+    pass
 
 
 class TSDFPolars(TSDF):
@@ -19,8 +19,4 @@ class TSDFPolars(TSDF):
     @staticmethod
     def from_tstore(base_dir: str) -> "TSDFPolars":
         """Read TStore into TSDF object."""
-        raise NotImplementedError
-
-    def to_tslong(self) -> "TSLongPolars":
-        """Convert the wrapper into a TSLong object."""
         raise NotImplementedError

--- a/tstore/tsdf/polars.py
+++ b/tstore/tsdf/polars.py
@@ -1,0 +1,26 @@
+"""TSDF class wrapping a Polars dataframe of TSArray objects."""
+
+from typing import TYPE_CHECKING
+
+from tstore.tsdf.tsdf import TSDF
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.polars import TSLongPolars
+
+
+class TSDFPolars(TSDF):
+    """A dataframe class with additional functionality for TSArray data."""
+
+    def to_tstore(self):
+        """Write TStore from TSDF object."""
+        raise NotImplementedError
+
+    @staticmethod
+    def from_tstore(base_dir: str) -> "TSDFPolars":
+        """Read TStore into TSDF object."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongPolars":
+        """Convert the wrapper into a TSLong object."""
+        raise NotImplementedError

--- a/tstore/tsdf/pyarrow.py
+++ b/tstore/tsdf/pyarrow.py
@@ -1,0 +1,26 @@
+"""TSDF class wrapping a PyArrow dataframe of TSArray objects."""
+
+from typing import TYPE_CHECKING
+
+from tstore.tsdf.tsdf import TSDF
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.pyarrow import TSLongPyArrow
+
+
+class TSDFPyArrow(TSDF):
+    """A dataframe class with additional functionality for TSArray data."""
+
+    def to_tstore(self):
+        """Write TStore from TSDF object."""
+        raise NotImplementedError
+
+    @staticmethod
+    def from_tstore(base_dir: str) -> "TSDFPyArrow":
+        """Read TStore into TSDF object."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongPyArrow":
+        """Convert the wrapper into a TSLong object."""
+        raise NotImplementedError

--- a/tstore/tsdf/pyarrow.py
+++ b/tstore/tsdf/pyarrow.py
@@ -6,7 +6,7 @@ from tstore.tsdf.tsdf import TSDF, get_ts_columns
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tslong.pyarrow import TSLongPyArrow
+    pass
 
 
 class TSDFPyArrow(TSDF):
@@ -31,7 +31,3 @@ class TSDFPyArrow(TSDF):
             col: [var for var in ts_obj._obj.schema.names if var != ts_obj._tstore_time_var]
             for col, ts_obj in ts_objects.items()
         }
-
-    def to_tslong(self) -> "TSLongPyArrow":
-        """Convert the wrapper into a TSLong object."""
-        raise NotImplementedError

--- a/tstore/tsdf/pyarrow.py
+++ b/tstore/tsdf/pyarrow.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from tstore.tsdf.tsdf import TSDF
+from tstore.tsdf.tsdf import TSDF, get_ts_columns
 
 if TYPE_CHECKING:
     # To avoid circular imports
@@ -20,6 +20,17 @@ class TSDFPyArrow(TSDF):
     def from_tstore(base_dir: str) -> "TSDFPyArrow":
         """Read TStore into TSDF object."""
         raise NotImplementedError
+
+    @property
+    def _tstore_ts_vars(self) -> dict[str, list[str]]:
+        """Return the dictionary of time-series column names."""
+        df = self._obj
+        ts_cols = get_ts_columns(df)
+        ts_objects = {col: df[col].iloc[0] for col in ts_cols}
+        return {
+            col: [var for var in ts_obj._obj.schema.names if var != ts_obj._tstore_time_var]
+            for col, ts_obj in ts_objects.items()
+        }
 
     def to_tslong(self) -> "TSLongPyArrow":
         """Convert the wrapper into a TSLong object."""

--- a/tstore/tsdf/reader.py
+++ b/tstore/tsdf/reader.py
@@ -18,7 +18,7 @@ def _read_tsarray(base_dir, ts_variable):
     ts_fpaths, tstore_ids, partitions = get_ts_info(base_dir=base_dir, ts_variable=ts_variable)
     # Read TS objects
     # TODO: add option for TS format (dask, pandas, ...)
-    list_ts = [TS.from_file(fpath, partitions=partitions) for fpath in ts_fpaths]
+    list_ts = [TS.from_disk(fpath, partitions=partitions) for fpath in ts_fpaths]
 
     # Create the TSArray Series
     tstore_ids = pd.Index(tstore_ids, dtype="string[pyarrow]", name="tstore_id")  # TODO: generalize

--- a/tstore/tsdf/ts_class.py
+++ b/tstore/tsdf/ts_class.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from tstore.archive.partitions import add_partitioning_columns
-from tstore.backend import DataFrame
+from tstore.backend import DataFrame, change_backend
 
 
 def check_time_index(df):
@@ -42,8 +42,13 @@ class TS:
         self._obj = df
         self._tstore_time_var = time_var
 
+    def change_backend(self, new_backend):
+        """Return a new TS object with the dataframe converted to a different backend."""
+        new_df = change_backend(self._obj, new_backend)
+        return TS(new_df, time_var=self._tstore_time_var)
+
     @staticmethod
-    def from_file(
+    def from_disk(
         fpath,
         partitions,
         columns=None,

--- a/tstore/tsdf/ts_class.py
+++ b/tstore/tsdf/ts_class.py
@@ -9,6 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from tstore.archive.partitions import add_partitioning_columns
+from tstore.backend import DataFrame
 
 
 def check_time_index(df):
@@ -29,13 +30,17 @@ def ensure_is_dask_dataframe(data):
 class TS:
     """TS object."""
 
-    def __init__(self, data):
+    def __init__(
+        self,
+        df: DataFrame,
+        time_var="time",
+    ):
         """Initialize TS class."""
         # Set index as 'time'
         # --> TODO: this to adapt for polars, pyarrow ...
-        data.index.name = "time"
-
-        self.data = data
+        df.index.name = time_var
+        self._obj = df
+        self._tstore_time_var = time_var
 
     @staticmethod
     def from_file(
@@ -77,7 +82,7 @@ class TS:
         # --> All code should exploit the arrow write_partitioned_dataset() function
 
         # Ensure is a dask dataframe
-        df = ensure_is_dask_dataframe(self.data)
+        df = ensure_is_dask_dataframe(self._obj)
 
         # Check the index is datetime
         check_time_index(df)
@@ -118,6 +123,6 @@ class TS:
     def __repr__(self):
         """Print TS object."""
         try:
-            return f"TS[shape={self.data.shape},start={self.data.index.min()},end={self.data.index.max()}]"
+            return f"TS[shape={self._obj.shape},start={self._obj.index.min()},end={self._obj.index.max()}]"
         except Exception:
-            return self.data.__repr__()
+            return self._obj.__repr__()

--- a/tstore/tsdf/ts_class.py
+++ b/tstore/tsdf/ts_class.py
@@ -37,6 +37,7 @@ class TS:
 
         self.data = data
 
+    @staticmethod
     def from_file(
         fpath,
         partitions,

--- a/tstore/tsdf/ts_class.py
+++ b/tstore/tsdf/ts_class.py
@@ -36,7 +36,8 @@ class TS:
         time_var="time",
     ):
         """Initialize TS class."""
-        df = re_set_dataframe_index(df, time_var)
+        # Ensure correct index column
+        df = re_set_dataframe_index(df, index_var=time_var)
         self._obj = df
         self._tstore_time_var = time_var
 

--- a/tstore/tsdf/ts_class.py
+++ b/tstore/tsdf/ts_class.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from tstore.archive.partitions import add_partitioning_columns
-from tstore.backend import Backend, DataFrame, change_backend, re_set_dataframe_index
+from tstore.backend import Backend, DataFrame, change_backend, get_backend, re_set_dataframe_index
 
 
 def check_time_index(df):
@@ -45,6 +45,11 @@ class TS:
         """Return a new TS object with the dataframe converted to a different backend."""
         new_df = change_backend(self._obj, new_backend, index_var=self._tstore_time_var)
         return TS(new_df, time_var=self._tstore_time_var)
+
+    @property
+    def current_backend(self):
+        """Return the backend of the wrapped dataframe."""
+        return get_backend(self._obj)
 
     @staticmethod
     def from_disk(

--- a/tstore/tsdf/tsarray.py
+++ b/tstore/tsdf/tsarray.py
@@ -61,7 +61,7 @@ class TSArray(ExtensionArray):
         # --> Need to create empty object !
         # TS[empty]
         ts_object = self._data[0]
-        tabular_object = getattr(ts_object, "data", pd.Series())
+        tabular_object = getattr(ts_object, "_obj", pd.Series())
         ts_class = get_tabular_object_type(tabular_object)
         return ts_class
 

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -1,6 +1,7 @@
 """Module defining the TSDF abstract wrapper for a dataframe of TSArray objects."""
 
 from tstore.backend import DataFrame, PandasDataFrame
+from tstore.tsdf.ts_dtype import TSDtype
 from tstore.tswrapper.tswrapper import TSWrapper
 
 
@@ -48,3 +49,25 @@ class TSDF(TSWrapper):
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSDF object.")
+
+    @property
+    def _tstore_ts_vars(self) -> dict[str, list[str]]:
+        """Return the dictionary of time-series column names."""
+        df = self._obj
+
+        ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
+
+        ts_objects = {col: df[col].iloc[0] for col in ts_cols}
+
+        return {col: list(ts_obj.columns) for col, ts_obj in ts_objects.items()}
+
+    @property
+    def _tstore_static_vars(self) -> list[str]:
+        """Return the list of static column names."""
+        df = self._obj
+
+        return [
+            col
+            for col in df.columns
+            if col != self._tstore_id_var and col != self._tstore_time_var and not isinstance(df[col].dtype, TSDtype)
+        ]

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -3,7 +3,15 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from tstore.backend import DataFrame, remove_dataframe_index
+from tstore.backend import (
+    Backend,
+    DaskDataFrame,
+    DataFrame,
+    PandasDataFrame,
+    PolarsDataFrame,
+    PyArrowDataFrame,
+    remove_dataframe_index,
+)
 from tstore.tsdf.ts_dtype import TSDtype
 from tstore.tswrapper.tswrapper import TSWrapper
 
@@ -27,6 +35,11 @@ class TSDF(TSWrapper):
             df (DataFrame): DataFrame to wrap.
             id_var (str): Name of the column containing the identifier variable.
         """
+        if not isinstance(df, PandasDataFrame):
+            raise TypeError(
+                "The input dataframe must be a Pandas DataFrame. Inner TS objects can contain dataframes of any type.",
+            )
+
         df = remove_dataframe_index(df)
         super().__init__(df)
         # Set attributes using __dict__ to not trigger __setattr__
@@ -43,18 +56,43 @@ class TSDF(TSWrapper):
 
         return super().__new__(cls)
 
+    def change_backend(self, new_backend: Backend) -> "TSDF":
+        """Return a new TSDF object with dataframes wrapped in internal TS objects converted to a different backend."""
+        df = self._obj.copy()
+        ts_cols = _get_ts_columns(df)
+
+        df[ts_cols] = df[ts_cols].applymap(lambda ts_obj: ts_obj.change_backend(new_backend))
+        df[ts_cols] = df[ts_cols].astype(TSDtype)
+
+        return self.wrap(df, self._tstore_id_var)
+
     @staticmethod
     @TSWrapper.copy_signature(__init__)
     def wrap(df: DataFrame, *args, **kwargs) -> "TSDF":
         """Wrap a DataFrame in the appropriate TSDF subclass."""
         # Lazy import to avoid circular imports
         from tstore.tsdf.dask import TSDFDask
+        from tstore.tsdf.pandas import TSDFPandas
+        from tstore.tsdf.polars import TSDFPolars
+        from tstore.tsdf.pyarrow import TSDFPyArrow
 
-        # TODO: check dataframe type inside TS objects
-        # if isinstance(df, DaskDataFrame):
-        return TSDFDask(df, *args, **kwargs)
+        ts_cols = _get_ts_columns(df)
+        ts_object = df[ts_cols[0]].iloc[0]
+        inner_df = ts_object._obj
 
-        type_path = f"{type(df).__module__}.{type(df).__qualname__}"
+        if isinstance(inner_df, DaskDataFrame):
+            return TSDFDask(df, *args, **kwargs)
+
+        if isinstance(inner_df, PandasDataFrame):
+            return TSDFPandas(df, *args, **kwargs)
+
+        if isinstance(inner_df, PolarsDataFrame):
+            return TSDFPolars(df, *args, **kwargs)
+
+        if isinstance(inner_df, PyArrowDataFrame):
+            return TSDFPyArrow(df, *args, **kwargs)
+
+        type_path = f"{type(inner_df).__module__}.{type(inner_df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSDF object.")
 
     @abstractmethod
@@ -69,7 +107,7 @@ class TSDF(TSWrapper):
     def _tstore_ts_vars(self) -> dict[str, list[str]]:
         """Return the dictionary of time-series column names."""
         df = self._obj
-        ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
+        ts_cols = _get_ts_columns(df)
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
         return {
             col: [var for var in ts_obj._obj.columns if var != ts_obj._tstore_time_var]
@@ -82,3 +120,8 @@ class TSDF(TSWrapper):
         df = self._obj
 
         return [col for col in df.columns if col != self._tstore_id_var and not isinstance(df[col].dtype, TSDtype)]
+
+
+def _get_ts_columns(df: PandasDataFrame) -> list[str]:
+    """Return the list of columns containing TS objects."""
+    return [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -54,12 +54,9 @@ class TSDF(TSWrapper):
     def _tstore_ts_vars(self) -> dict[str, list[str]]:
         """Return the dictionary of time-series column names."""
         df = self._obj
-
         ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
-
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
-
-        return {col: list(ts_obj.columns) for col, ts_obj in ts_objects.items()}
+        return {col: list(ts_obj.data.columns) for col, ts_obj in ts_objects.items()}
 
     @property
     def _tstore_static_vars(self) -> list[str]:

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -59,7 +59,7 @@ class TSDF(TSWrapper):
     def change_backend(self, new_backend: Backend) -> "TSDF":
         """Return a new TSDF object with dataframes wrapped in internal TS objects converted to a different backend."""
         df = self._obj.copy()
-        ts_cols = _get_ts_columns(df)
+        ts_cols = get_ts_columns(df)
 
         df[ts_cols] = df[ts_cols].applymap(lambda ts_obj: ts_obj.change_backend(new_backend))
         df[ts_cols] = df[ts_cols].astype(TSDtype)
@@ -70,7 +70,7 @@ class TSDF(TSWrapper):
     def current_backend(self) -> Backend:
         """Return the current backend of the wrapped dataframe."""
         df = self._obj.copy()
-        ts_cols = _get_ts_columns(df)
+        ts_cols = get_ts_columns(df)
         ts_object = df[ts_cols[0]].iloc[0]
         return ts_object.current_backend
 
@@ -84,7 +84,7 @@ class TSDF(TSWrapper):
         from tstore.tsdf.polars import TSDFPolars
         from tstore.tsdf.pyarrow import TSDFPyArrow
 
-        ts_cols = _get_ts_columns(df)
+        ts_cols = get_ts_columns(df)
         ts_object = df[ts_cols[0]].iloc[0]
         inner_df = ts_object._obj
 
@@ -115,7 +115,7 @@ class TSDF(TSWrapper):
     def _tstore_ts_vars(self) -> dict[str, list[str]]:
         """Return the dictionary of time-series column names."""
         df = self._obj
-        ts_cols = _get_ts_columns(df)
+        ts_cols = get_ts_columns(df)
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
         return {
             col: [var for var in ts_obj._obj.columns if var != ts_obj._tstore_time_var]
@@ -130,6 +130,6 @@ class TSDF(TSWrapper):
         return [col for col in df.columns if col != self._tstore_id_var and not isinstance(df[col].dtype, TSDtype)]
 
 
-def _get_ts_columns(df: PandasDataFrame) -> list[str]:
+def get_ts_columns(df: PandasDataFrame) -> list[str]:
     """Return the list of columns containing TS objects."""
     return [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -72,15 +72,14 @@ class TSDF(TSWrapper):
         df = self._obj
         ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
-        return {col: list(ts_obj.data.columns) for col, ts_obj in ts_objects.items()}
+        return {
+            col: [var for var in ts_obj.data.columns if var != self._tstore_time_var]
+            for col, ts_obj in ts_objects.items()
+        }
 
     @property
     def _tstore_static_vars(self) -> list[str]:
         """Return the list of static column names."""
         df = self._obj
 
-        return [
-            col
-            for col in df.columns
-            if col != self._tstore_id_var and col != self._tstore_time_var and not isinstance(df[col].dtype, TSDtype)
-        ]
+        return [col for col in df.columns if col != self._tstore_id_var and not isinstance(df[col].dtype, TSDtype)]

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -1,8 +1,16 @@
 """Module defining the TSDF abstract wrapper for a dataframe of TSArray objects."""
 
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
 from tstore.backend import DataFrame, PandasDataFrame
 from tstore.tsdf.ts_dtype import TSDtype
 from tstore.tswrapper.tswrapper import TSWrapper
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.tslong import TSLong
+    from tstore.tswide.tswide import TSWide
 
 
 class TSDF(TSWrapper):
@@ -49,6 +57,14 @@ class TSDF(TSWrapper):
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSDF object.")
+
+    @abstractmethod
+    def to_tslong(self) -> "TSLong":
+        """Convert the wrapper into a TSLong object."""
+
+    def to_tswide(self) -> "TSWide":
+        """Convert the wrapper into a TSWide object."""
+        return self.to_tslong().to_tswide()
 
     @property
     def _tstore_ts_vars(self) -> dict[str, list[str]]:

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -73,7 +73,7 @@ class TSDF(TSWrapper):
         ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
         return {
-            col: [var for var in ts_obj.data.columns if var != self._tstore_time_var]
+            col: [var for var in ts_obj._obj.columns if var != self._tstore_time_var]
             for col, ts_obj in ts_objects.items()
         }
 

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from tstore.backend import DataFrame
+from tstore.backend import DataFrame, remove_dataframe_index
 from tstore.tsdf.ts_dtype import TSDtype
 from tstore.tswrapper.tswrapper import TSWrapper
 
@@ -20,21 +20,19 @@ class TSDF(TSWrapper):
         self,
         df: DataFrame,
         id_var: str,
-        time_var: str = "time",
     ) -> None:
         """Wrap a DataFrame of TSArrays as a TSDF object.
 
         Args:
             df (DataFrame): DataFrame to wrap.
             id_var (str): Name of the column containing the identifier variable.
-            time_var (str): Name of the column containing the time variable. Defaults to "time".
         """
+        df = remove_dataframe_index(df)
         super().__init__(df)
         # Set attributes using __dict__ to not trigger __setattr__
         self.__dict__.update(
             {
                 "_tstore_id_var": id_var,
-                "_tstore_time_var": time_var,
             },
         )
 
@@ -74,7 +72,7 @@ class TSDF(TSWrapper):
         ts_cols = [col for col in df.columns if isinstance(df[col].dtype, TSDtype)]
         ts_objects = {col: df[col].iloc[0] for col in ts_cols}
         return {
-            col: [var for var in ts_obj._obj.columns if var != self._tstore_time_var]
+            col: [var for var in ts_obj._obj.columns if var != ts_obj._tstore_time_var]
             for col, ts_obj in ts_objects.items()
         }
 

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -1,6 +1,5 @@
 """Module defining the TSDF abstract wrapper for a dataframe of TSArray objects."""
 
-from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from tstore.backend import (
@@ -103,9 +102,12 @@ class TSDF(TSWrapper):
         type_path = f"{type(inner_df).__module__}.{type(inner_df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSDF object.")
 
-    @abstractmethod
     def to_tslong(self) -> "TSLong":
         """Convert the wrapper into a TSLong object."""
+        dask_tsdf = self.change_backend(new_backend="dask")
+        dask_tslong = dask_tsdf.to_tslong()
+        tslong = dask_tslong.change_backend(new_backend=self.current_backend)
+        return tslong
 
     def to_tswide(self) -> "TSWide":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from tstore.backend import DataFrame, PandasDataFrame
+from tstore.backend import DataFrame
 from tstore.tsdf.ts_dtype import TSDtype
 from tstore.tswrapper.tswrapper import TSWrapper
 
@@ -50,10 +50,11 @@ class TSDF(TSWrapper):
     def wrap(df: DataFrame, *args, **kwargs) -> "TSDF":
         """Wrap a DataFrame in the appropriate TSDF subclass."""
         # Lazy import to avoid circular imports
-        from tstore.tsdf.pandas import TSDFPandas
+        from tstore.tsdf.dask import TSDFDask
 
-        if isinstance(df, PandasDataFrame):
-            return TSDFPandas(df, *args, **kwargs)
+        # TODO: check dataframe type inside TS objects
+        # if isinstance(df, DaskDataFrame):
+        return TSDFDask(df, *args, **kwargs)
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSDF object.")

--- a/tstore/tsdf/tsdf.py
+++ b/tstore/tsdf/tsdf.py
@@ -66,6 +66,14 @@ class TSDF(TSWrapper):
 
         return self.wrap(df, self._tstore_id_var)
 
+    @property
+    def current_backend(self) -> Backend:
+        """Return the current backend of the wrapped dataframe."""
+        df = self._obj.copy()
+        ts_cols = _get_ts_columns(df)
+        ts_object = df[ts_cols[0]].iloc[0]
+        return ts_object.current_backend
+
     @staticmethod
     @TSWrapper.copy_signature(__init__)
     def wrap(df: DataFrame, *args, **kwargs) -> "TSDF":

--- a/tstore/tsdf/writer.py
+++ b/tstore/tsdf/writer.py
@@ -41,10 +41,9 @@ def _write_attributes(df, base_dir):
     write_attributes(df=df_attributes, base_dir=base_dir)
 
 
-def _write_ts_series(ts_series, base_dir, tstore_structure):
+def _write_ts_series(ts_series, tstore_ids, base_dir, tstore_structure):
     """Write TSDF TSArray."""
     ts_variable = ts_series.name
-    tstore_ids = ts_series.index.array.astype(str)
     for tstore_id, ts in zip(tstore_ids, ts_series):
         if ts:  # not empty
             ts_fpath = define_tsarray_filepath(
@@ -56,12 +55,13 @@ def _write_ts_series(ts_series, base_dir, tstore_structure):
             ts.to_disk(ts_fpath)
 
 
-def _write_tsarrays(df, base_dir, tstore_structure):
+def _write_tsarrays(df, id_var, base_dir, tstore_structure):
     """Write TSDF TSArrays."""
     tsarray_columns = _get_ts_variables(df)
     for column in tsarray_columns:
         _write_ts_series(
             ts_series=df[column],
+            tstore_ids=df[id_var],
             base_dir=base_dir,
             tstore_structure=tstore_structure,
         )
@@ -102,7 +102,7 @@ def write_tstore(
     _write_attributes(df, base_dir=base_dir)
 
     # Write TSArrays
-    _write_tsarrays(df, base_dir=base_dir, tstore_structure=tstore_structure)
+    _write_tsarrays(df, id_var, base_dir=base_dir, tstore_structure=tstore_structure)
 
     # Write TSArrays metadata
     ts_variables = _get_ts_variables(df)

--- a/tstore/tsdf/writer.py
+++ b/tstore/tsdf/writer.py
@@ -67,14 +67,13 @@ def _write_tsarrays(df, id_var, base_dir, tstore_structure):
         )
 
 
-def _write_metadata(base_dir, tstore_structure, id_var, time_var, ts_variables, partitioning):
+def _write_metadata(base_dir, tstore_structure, id_var, ts_variables, partitioning):
     """Write TStore metadata."""
     from tstore.archive.metadata.writers import write_tstore_metadata
 
     write_tstore_metadata(
         base_dir=base_dir,
         id_var=id_var,
-        time_var=time_var,
         ts_variables=ts_variables,
         tstore_structure=tstore_structure,
         partitioning=partitioning,
@@ -85,7 +84,6 @@ def write_tstore(
     df,
     base_dir,
     id_var,
-    time_var,  # maybe not needed for TSDF?
     partitioning,
     tstore_structure="id-var",
     overwrite=True,
@@ -111,6 +109,5 @@ def write_tstore(
         tstore_structure=tstore_structure,
         ts_variables=ts_variables,
         id_var=id_var,
-        time_var=time_var,
         partitioning=partitioning,
     )

--- a/tstore/tslong/__init__.py
+++ b/tstore/tslong/__init__.py
@@ -11,7 +11,7 @@ from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
 
 
-def open_tslong(base_dir: Union[str, Path], *args, backend: Backend = "pandas", **kwargs):
+def open_tslong(base_dir: Union[str, Path], *args, backend: Backend = "dask", **kwargs):
     """Read a TStore file structure as a TSLong object."""
     ts_long_classes = {
         "dask": TSLongDask,

--- a/tstore/tslong/dask.py
+++ b/tstore/tslong/dask.py
@@ -2,6 +2,10 @@
 
 from typing import TYPE_CHECKING
 
+import pandas as pd
+
+from tstore.tsdf.ts_class import TS
+from tstore.tsdf.tsarray import TSArray
 from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
 
@@ -59,7 +63,62 @@ class TSLongDask(TSLong):
 
     def to_tsdf(self) -> "TSDFDask":
         """Convert the wrapper into a TSDFDask object."""
-        raise NotImplementedError
+        from tstore.tsdf.dask import TSDFDask
+
+        tstore_ids = self._get_tstore_ids()
+        ts_arrays = self._get_ts_arrays()
+        pd_series = {ts_variable: pd.Series(ts_array, index=tstore_ids) for ts_variable, ts_array in ts_arrays.items()}
+        static_values = self._get_static_values()
+        data = {**pd_series, **static_values, self._tstore_id_var: tstore_ids}
+
+        df = pd.DataFrame(data)
+        return TSDFDask(
+            df,
+            id_var=self._tstore_id_var,
+        )
+
+    def _get_tstore_ids(self) -> list:
+        """Retrieve the list of tstore ids."""
+        return sorted(self._obj[self._tstore_id_var].unique())
+
+    def _get_ts_arrays(self) -> dict[str, TSArray]:
+        """Create a dictionary of TSArrays."""
+        return {ts_variable: self._get_ts_array(variables) for ts_variable, variables in self._tstore_ts_vars.items()}
+
+    def _get_ts_array(self, variables: list[str]) -> TSArray:
+        """Create a TSArray for a set of variables."""
+        tstore_ids = self._get_tstore_ids()
+        ts_list = [self._get_ts(tstore_id, variables) for tstore_id in tstore_ids]
+        return TSArray(ts_list)
+
+    def _get_ts(self, tstore_id: str, variables: list[str]) -> TS:
+        """Create a TS object for a given tstore_id and a set of variables."""
+        df = self._obj
+        df = df[df[self._tstore_id_var] == tstore_id]
+        df = df[variables]
+        return TS(df)
+
+    def _get_static_values(self) -> dict[str, list]:
+        """Retrieve the static values."""
+        df = self._obj
+        tstore_ids = self._get_tstore_ids()
+        static_values = {}
+
+        for static_var in self._tstore_static_vars:
+            var_static_values = []
+            for tstore_id in tstore_ids:
+                values = df[df[self._tstore_id_var] == tstore_id][static_var].unique().compute()
+
+                if len(values) > 1:
+                    raise ValueError(
+                        f"Static variables should be unique per tstore_id. Found {list(values)} for {static_var}.",
+                    )
+
+                var_static_values.append(values[0])
+
+            static_values[static_var] = var_static_values
+
+        return static_values
 
     def to_tswide(self) -> "TSWideDask":
         """Convert the wrapper into a TSWideDask object."""

--- a/tstore/tslong/dask.py
+++ b/tstore/tslong/dask.py
@@ -1,6 +1,13 @@
 """Module defining the TSLongDask wrapper."""
 
+from typing import TYPE_CHECKING
+
 from tstore.tslong.tslong import TSLong
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.dask import TSDFDask
+    from tstore.tswide.dask import TSWideDask
 
 
 class TSLongDask(TSLong):
@@ -13,4 +20,12 @@ class TSLongDask(TSLong):
     @staticmethod
     def from_tstore(base_dir) -> "TSLongDask":
         """Open a TStore file structure as a TSLongDask wrapper around a Dask long dataframe."""
+        raise NotImplementedError
+
+    def to_tsdf(self) -> "TSDFDask":
+        """Convert the wrapper into a TSDFDask object."""
+        raise NotImplementedError
+
+    def to_tswide(self) -> "TSWideDask":
+        """Convert the wrapper into a TSWideDask object."""
         raise NotImplementedError

--- a/tstore/tslong/dask.py
+++ b/tstore/tslong/dask.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
@@ -13,14 +14,48 @@ if TYPE_CHECKING:
 class TSLongDask(TSLong):
     """Wrapper for a long-form Dask timeseries dataframe."""
 
-    def to_tstore(self):
+    def to_tstore(
+        self,
+        base_dir,
+        partitioning=None,
+        tstore_structure="id-var",
+        overwrite=True,
+    ):
         """Write the wrapped dataframe as a TStore structure."""
-        raise NotImplementedError
+        pandas_tslong = self.change_backend(new_backend="pandas")
+        pandas_tslong.to_tstore(
+            base_dir=base_dir,
+            partitioning=partitioning,
+            tstore_structure=tstore_structure,
+            overwrite=overwrite,
+        )
 
     @staticmethod
-    def from_tstore(base_dir) -> "TSLongDask":
-        """Open a TStore file structure as a TSLongDask wrapper around a Dask long dataframe."""
-        raise NotImplementedError
+    def from_tstore(
+        base_dir,
+        ts_variables=None,
+        start_time=None,
+        end_time=None,
+        tstore_ids=None,
+        columns=None,
+        filesystem=None,
+        use_threads=True,
+    ) -> "TSLongDask":
+        """Open a TStore file structure as a TSLongDask wrapper around a Pandas long dataframe."""
+        # Read exploiting pyarrow
+        tslong_pyarrow = TSLongPyArrow.from_tstore(
+            base_dir,
+            ts_variables=ts_variables,
+            start_time=start_time,
+            end_time=end_time,
+            tstore_ids=tstore_ids,
+            columns=columns,
+            filesystem=filesystem,
+            use_threads=use_threads,
+        )
+
+        # Conversion to pandas
+        return tslong_pyarrow.change_backend(new_backend="dask")
 
     def to_tsdf(self) -> "TSDFDask":
         """Convert the wrapper into a TSDFDask object."""

--- a/tstore/tslong/dask.py
+++ b/tstore/tslong/dask.py
@@ -122,4 +122,22 @@ class TSLongDask(TSLong):
 
     def to_tswide(self) -> "TSWideDask":
         """Convert the wrapper into a TSWideDask object."""
-        raise NotImplementedError
+        from tstore.tswide.dask import TSWideDask
+
+        df = self._obj
+        df = df.reset_index()
+        df[self._tstore_id_var] = df[self._tstore_id_var].astype("category").compute()
+        df = df.pivot_table(
+            index=self._tstore_time_var,
+            columns=self._tstore_id_var,
+            values=df.columns.difference([self._tstore_id_var]),
+            aggfunc="first",
+        )
+
+        return TSWideDask(
+            df,
+            id_var=self._tstore_id_var,
+            time_var=self._tstore_time_var,
+            ts_vars=self._tstore_ts_vars,
+            static_vars=self._tstore_static_vars,
+        )

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -35,12 +35,12 @@ class TSLongPandas(TSLong):
     ):
         """Write the wrapped dataframe as a TStore structure."""
         # If index time, remove
-        if time_var not in self._df.columns:
-            self._df = self._df.reset_index(names=time_var)
+        if time_var not in self._obj.columns:
+            self._obj = self._obj.reset_index(names=time_var)
 
         # Set identifier as pyarrow large_string !
         # - Very important to join attrs at read time !
-        self._df[id_var] = self._df[id_var].astype("large_string[pyarrow]")
+        self._obj[id_var] = self._obj[id_var].astype("large_string[pyarrow]")
 
         # Check inputs
         tstore_structure = check_tstore_structure(tstore_structure)
@@ -64,7 +64,7 @@ class TSLongPandas(TSLong):
         if static_variables is not None:
             attr_cols += static_variables
         # - TODO: add flag to check if are actual duplicates !
-        df_attrs = self._df[attr_cols]
+        df_attrs = self._obj[attr_cols]
         df_attrs = df_attrs.drop_duplicates(subset=id_var)
         df_attrs = df_attrs.reset_index(drop=True)
 
@@ -89,7 +89,7 @@ class TSLongPandas(TSLong):
         )
 
         # Write to disk per identifier
-        for tstore_id, df_group in self._df.groupby(id_var):
+        for tstore_id, df_group in self._obj.groupby(id_var):
             for ts_variable, columns in ts_variables.items():
                 # Retrieve columns of the TS object
                 if columns is None:
@@ -160,7 +160,7 @@ class TSLongPandas(TSLong):
             columns=columns,
             filesystem=filesystem,
             use_threads=use_threads,
-        )._df
+        )._obj
 
         # Conversion to pandas
         tslong_pandas = tslong_pyarrow.to_pandas(types_mapper=pd.ArrowDtype)

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+import pandas as pd
 import pyarrow as pa
 
 from tstore.archive.io import (
@@ -13,6 +14,8 @@ from tstore.archive.io import (
 from tstore.archive.metadata.writers import write_tstore_metadata
 from tstore.archive.partitions import add_partitioning_columns, check_partitioning
 from tstore.archive.ts.writers.pyarrow import write_partitioned_dataset
+from tstore.tsdf.ts_class import TS
+from tstore.tsdf.tsarray import TSArray
 from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
 
@@ -167,7 +170,63 @@ class TSLongPandas(TSLong):
 
     def to_tsdf(self) -> "TSDFPandas":
         """Convert the wrapper into a TSDF object."""
-        raise NotImplementedError
+        from tstore.tsdf.pandas import TSDFPandas
+
+        tstore_ids = self._get_tstore_ids()
+        ts_arrays = self._get_ts_arrays()
+        pd_series = {ts_variable: pd.Series(ts_array, index=tstore_ids) for ts_variable, ts_array in ts_arrays.items()}
+        static_values = self._get_static_values()
+        data = {**pd_series, **static_values, self._tstore_id_var: tstore_ids}
+
+        df = pd.DataFrame(data)
+        return TSDFPandas(
+            df,
+            id_var=self._tstore_id_var,
+            time_var=self._tstore_time_var,
+        )
+
+    def _get_tstore_ids(self) -> list:
+        """Retrieve the list of tstore ids."""
+        return sorted(self._obj[self._tstore_id_var].unique())
+
+    def _get_ts_arrays(self) -> dict[str, TSArray]:
+        """Create a dictionary of TSArrays."""
+        return {ts_variable: self._get_ts_array(variables) for ts_variable, variables in self._tstore_ts_vars.items()}
+
+    def _get_ts_array(self, variables: list[str]) -> TSArray:
+        """Create a TSArray for a set of variables."""
+        tstore_ids = self._get_tstore_ids()
+        ts_list = [self._get_ts(tstore_id, variables) for tstore_id in tstore_ids]
+        return TSArray(ts_list)
+
+    def _get_ts(self, tstore_id: str, variables: list[str]) -> TS:
+        """Create a TS object for a given tstore_id and a set of variables."""
+        df = self._obj
+        df = df[df[self._tstore_id_var] == tstore_id]
+        df = df[[self._tstore_time_var, *variables]]
+        return TS(df)
+
+    def _get_static_values(self) -> dict[str, list]:
+        """Retrieve the static values."""
+        df = self._obj
+        tstore_ids = self._get_tstore_ids()
+        static_values = {}
+
+        for static_var in self._tstore_static_vars:
+            var_static_values = []
+            for tstore_id in tstore_ids:
+                values = df[df[self._tstore_id_var] == tstore_id][static_var].unique()
+
+                if len(values) > 1:
+                    raise ValueError(
+                        f"Static variables should be unique per tstore_id. Found {list(values)} for {static_var}.",
+                    )
+
+                var_static_values.append(values[0])
+
+            static_values[static_var] = var_static_values
+
+        return static_values
 
     def to_tswide(self) -> "TSWidePandas":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import pyarrow as pa
 
 from tstore.archive.io import (
@@ -14,8 +13,6 @@ from tstore.archive.io import (
 from tstore.archive.metadata.writers import write_tstore_metadata
 from tstore.archive.partitions import add_partitioning_columns, check_partitioning
 from tstore.archive.ts.writers.pyarrow import write_partitioned_dataset
-from tstore.tsdf.ts_class import TS
-from tstore.tsdf.tsarray import TSArray
 from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
 
@@ -166,62 +163,10 @@ class TSLongPandas(TSLong):
 
     def to_tsdf(self) -> "TSDFPandas":
         """Convert the wrapper into a TSDF object."""
-        from tstore.tsdf.pandas import TSDFPandas
-
-        tstore_ids = self._get_tstore_ids()
-        ts_arrays = self._get_ts_arrays()
-        pd_series = {ts_variable: pd.Series(ts_array, index=tstore_ids) for ts_variable, ts_array in ts_arrays.items()}
-        static_values = self._get_static_values()
-        data = {**pd_series, **static_values, self._tstore_id_var: tstore_ids}
-
-        df = pd.DataFrame(data)
-        return TSDFPandas(
-            df,
-            id_var=self._tstore_id_var,
-        )
-
-    def _get_tstore_ids(self) -> list:
-        """Retrieve the list of tstore ids."""
-        return sorted(self._obj[self._tstore_id_var].unique())
-
-    def _get_ts_arrays(self) -> dict[str, TSArray]:
-        """Create a dictionary of TSArrays."""
-        return {ts_variable: self._get_ts_array(variables) for ts_variable, variables in self._tstore_ts_vars.items()}
-
-    def _get_ts_array(self, variables: list[str]) -> TSArray:
-        """Create a TSArray for a set of variables."""
-        tstore_ids = self._get_tstore_ids()
-        ts_list = [self._get_ts(tstore_id, variables) for tstore_id in tstore_ids]
-        return TSArray(ts_list)
-
-    def _get_ts(self, tstore_id: str, variables: list[str]) -> TS:
-        """Create a TS object for a given tstore_id and a set of variables."""
-        df = self._obj
-        df = df[df[self._tstore_id_var] == tstore_id]
-        df = df[[self._tstore_time_var, *variables]]
-        return TS(df)
-
-    def _get_static_values(self) -> dict[str, list]:
-        """Retrieve the static values."""
-        df = self._obj
-        tstore_ids = self._get_tstore_ids()
-        static_values = {}
-
-        for static_var in self._tstore_static_vars:
-            var_static_values = []
-            for tstore_id in tstore_ids:
-                values = df[df[self._tstore_id_var] == tstore_id][static_var].unique()
-
-                if len(values) > 1:
-                    raise ValueError(
-                        f"Static variables should be unique per tstore_id. Found {list(values)} for {static_var}.",
-                    )
-
-                var_static_values.append(values[0])
-
-            static_values[static_var] = var_static_values
-
-        return static_values
+        dask_tslong = self.change_backend(new_backend="dask")
+        dask_tsdf = dask_tslong.to_tsdf()
+        tsdf = dask_tsdf.change_backend(new_backend="pandas")
+        return tsdf
 
     def to_tswide(self) -> "TSWidePandas":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -162,4 +162,19 @@ class TSLongPandas(TSLong):
 
     def to_tswide(self) -> "TSWidePandas":
         """Convert the wrapper into a TSWide object."""
-        raise NotImplementedError
+        from tstore.tswide.pandas import TSWidePandas
+
+        df = self._obj
+        df = df.pivot_table(
+            index=self._tstore_time_var,
+            columns=self._tstore_id_var,
+            aggfunc="first",
+        )
+
+        return TSWidePandas(
+            df,
+            id_var=self._tstore_id_var,
+            time_var=self._tstore_time_var,
+            ts_vars=self._tstore_ts_vars,
+            static_vars=self._tstore_static_vars,
+        )

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -1,5 +1,7 @@
 """Module defining the TSLongPandas wrapper."""
 
+from typing import TYPE_CHECKING
+
 import pyarrow as pa
 
 from tstore.archive.io import (
@@ -13,6 +15,11 @@ from tstore.archive.partitions import add_partitioning_columns, check_partitioni
 from tstore.archive.ts.writers.pyarrow import write_partitioned_dataset
 from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.pandas import TSDFPandas
+    from tstore.tswide.pandas import TSWidePandas
 
 
 class TSLongPandas(TSLong):
@@ -157,3 +164,11 @@ class TSLongPandas(TSLong):
 
         # Conversion to pandas
         return tslong_pyarrow.change_backend(new_backend="pandas")
+
+    def to_tsdf(self) -> "TSDFPandas":
+        """Convert the wrapper into a TSDF object."""
+        raise NotImplementedError
+
+    def to_tswide(self) -> "TSWidePandas":
+        """Convert the wrapper into a TSWide object."""
+        raise NotImplementedError

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -37,12 +37,9 @@ class TSLongPandas(TSLong):
     ):
         """Write the wrapped dataframe as a TStore structure."""
         # If index time, remove
-        if self._tstore_time_var not in self._obj.columns:
-            self._obj = self._obj.reset_index(names=self._tstore_time_var)
-
-        # Set identifier as pyarrow large_string !
-        # - Very important to join attrs at read time !
-        self._obj[self._tstore_id_var] = self._obj[self._tstore_id_var].astype("large_string[pyarrow]")
+        df = self._obj
+        if self._tstore_time_var not in df.columns:
+            df = df.reset_index(names=self._tstore_time_var)
 
         # Check inputs
         tstore_structure = check_tstore_structure(tstore_structure)
@@ -67,7 +64,7 @@ class TSLongPandas(TSLong):
         if self._tstore_static_vars is not None:
             attr_cols += self._tstore_static_vars
         # - TODO: add flag to check if are actual duplicates !
-        df_attrs = self._obj[attr_cols]
+        df_attrs = df[attr_cols]
         df_attrs = df_attrs.drop_duplicates(subset=self._tstore_id_var)
         df_attrs = df_attrs.reset_index(drop=True)
 
@@ -91,7 +88,7 @@ class TSLongPandas(TSLong):
         )
 
         # Write to disk per identifier
-        for tstore_id, df_group in self._obj.groupby(self._tstore_id_var):
+        for tstore_id, df_group in df.groupby(self._tstore_id_var):
             for ts_variable, columns in ts_variables.items():
                 # Retrieve columns of the TS object
                 if columns is None:

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -18,7 +18,6 @@ from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tsdf.pandas import TSDFPandas
     from tstore.tswide.pandas import TSWidePandas
 
 
@@ -160,13 +159,6 @@ class TSLongPandas(TSLong):
 
         # Conversion to pandas
         return tslong_pyarrow.change_backend(new_backend="pandas")
-
-    def to_tsdf(self) -> "TSDFPandas":
-        """Convert the wrapper into a TSDF object."""
-        dask_tslong = self.change_backend(new_backend="dask")
-        dask_tsdf = dask_tslong.to_tsdf()
-        tsdf = dask_tsdf.change_backend(new_backend="pandas")
-        return tsdf
 
     def to_tswide(self) -> "TSWidePandas":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/pandas.py
+++ b/tstore/tslong/pandas.py
@@ -85,7 +85,6 @@ class TSLongPandas(TSLong):
         write_tstore_metadata(
             base_dir=base_dir,
             id_var=self._tstore_id_var,
-            time_var=self._tstore_time_var,
             ts_variables=list(ts_variables),
             tstore_structure=tstore_structure,
             partitioning=partitioning,
@@ -182,7 +181,6 @@ class TSLongPandas(TSLong):
         return TSDFPandas(
             df,
             id_var=self._tstore_id_var,
-            time_var=self._tstore_time_var,
         )
 
     def _get_tstore_ids(self) -> list:

--- a/tstore/tslong/polars.py
+++ b/tstore/tslong/polars.py
@@ -76,7 +76,6 @@ class TSLongPolars(TSLong):
         write_tstore_metadata(
             base_dir=base_dir,
             id_var=self._tstore_id_var,
-            time_var=self._tstore_time_var,
             ts_variables=list(ts_variables),
             tstore_structure=tstore_structure,
             partitioning=partitioning,

--- a/tstore/tslong/polars.py
+++ b/tstore/tslong/polars.py
@@ -18,7 +18,7 @@ from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tswide.polars import TSWidePolars
+    pass
 
 
 class TSLongPolars(TSLong):
@@ -155,7 +155,3 @@ class TSLongPolars(TSLong):
 
         # Conversion to polars
         return tslong_pyarrow.change_backend(new_backend="polars")
-
-    def to_tswide(self) -> "TSWidePolars":
-        """Convert the wrapper into a TSWide object."""
-        raise NotImplementedError

--- a/tstore/tslong/polars.py
+++ b/tstore/tslong/polars.py
@@ -1,5 +1,7 @@
 """Module defining the TSLongPolars wrapper."""
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 
 from tstore.archive.io import (
@@ -13,6 +15,11 @@ from tstore.archive.partitions import add_partitioning_columns, check_partitioni
 from tstore.archive.ts.writers.pyarrow import write_partitioned_dataset
 from tstore.tslong.pyarrow import TSLongPyArrow
 from tstore.tslong.tslong import TSLong
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.polars import TSDFPolars
+    from tstore.tswide.polars import TSWidePolars
 
 
 class TSLongPolars(TSLong):
@@ -150,3 +157,11 @@ class TSLongPolars(TSLong):
 
         # Conversion to polars
         return tslong_pyarrow.change_backend(new_backend="polars")
+
+    def to_tsdf(self) -> "TSDFPolars":
+        """Convert the wrapper into a TSDF object."""
+        raise NotImplementedError
+
+    def to_tswide(self) -> "TSWidePolars":
+        """Convert the wrapper into a TSWide object."""
+        raise NotImplementedError

--- a/tstore/tslong/polars.py
+++ b/tstore/tslong/polars.py
@@ -53,7 +53,7 @@ class TSLongPolars(TSLong):
 
         # Identify static dataframe (attributes)
         # - TODO: add flag to check if are actual duplicates !
-        df_attrs = self._df[[id_var, *static_variables]]
+        df_attrs = self._obj[[id_var, *static_variables]]
         df_attrs = df_attrs.unique()
 
         # Write static attributes
@@ -83,7 +83,7 @@ class TSLongPolars(TSLong):
         )
 
         # Write to disk per identifier
-        for tstore_id, df_group in self._df.groupby(id_var):
+        for tstore_id, df_group in self._obj.groupby(id_var):
             for ts_variable, columns in ts_variables.items():
                 # Retrieve columns of the TS object
                 if columns is None:
@@ -153,7 +153,7 @@ class TSLongPolars(TSLong):
             columns=columns,
             filesystem=filesystem,
             use_threads=use_threads,
-        )._df
+        )._obj
 
         # Conversion to polars
         tslong_pl = pl.from_arrow(tslong_pyarrow)

--- a/tstore/tslong/polars.py
+++ b/tstore/tslong/polars.py
@@ -18,7 +18,6 @@ from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tsdf.polars import TSDFPolars
     from tstore.tswide.polars import TSWidePolars
 
 
@@ -156,10 +155,6 @@ class TSLongPolars(TSLong):
 
         # Conversion to polars
         return tslong_pyarrow.change_backend(new_backend="polars")
-
-    def to_tsdf(self) -> "TSDFPolars":
-        """Convert the wrapper into a TSDF object."""
-        raise NotImplementedError
 
     def to_tswide(self) -> "TSWidePolars":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -19,7 +19,7 @@ from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tswide.pyarrow import TSWidePyArrow
+    pass
 
 
 class TSLongPyArrow(TSLong):
@@ -94,10 +94,6 @@ class TSLongPyArrow(TSLong):
             ts_vars=ts_variables_dict,
             static_vars=static_vars,
         )
-
-    def to_tswide(self) -> "TSWidePyArrow":
-        """Convert the wrapper into a TSWide object."""
-        raise NotImplementedError
 
 
 def _read_ts(

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -1,6 +1,7 @@
 """Module defining the TSLongPyArrow wrapper."""
 
 from functools import reduce
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
@@ -15,6 +16,11 @@ from tstore.archive.checks import (
 from tstore.archive.io import get_id_var, get_time_var, get_ts_info
 from tstore.archive.ts.readers.pyarrow import open_ts
 from tstore.tslong.tslong import TSLong
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.pyarrow import TSDFPyArrow
+    from tstore.tswide.pyarrow import TSWidePyArrow
 
 
 class TSLongPyArrow(TSLong):
@@ -77,6 +83,14 @@ class TSLongPyArrow(TSLong):
             ts_vars=ts_variables,
             static_vars=None,
         )
+
+    def to_tsdf(self) -> "TSDFPyArrow":
+        """Convert the wrapper into a TSDF object."""
+        raise NotImplementedError
+
+    def to_tswide(self) -> "TSWidePyArrow":
+        """Convert the wrapper into a TSWide object."""
+        raise NotImplementedError
 
 
 def _read_ts(

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -68,7 +68,15 @@ class TSLongPyArrow(TSLong):
         # Join (duplicate) table_attrs on table
         tslong = table.join(table_attrs, keys=[id_var], join_type="full outer")
 
-        return TSLongPyArrow(tslong)
+        # TODO: Add static variables
+
+        return TSLongPyArrow(
+            tslong,
+            id_var=id_var,
+            time_var=time_var,
+            ts_vars=ts_variables,
+            static_vars=None,
+        )
 
 
 def _read_ts(

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -26,9 +26,21 @@ if TYPE_CHECKING:
 class TSLongPyArrow(TSLong):
     """Wrapper for a long-form PyArrow timeseries dataframe."""
 
-    def to_tstore(self) -> None:
+    def to_tstore(
+        self,
+        base_dir,
+        partitioning=None,
+        tstore_structure="id-var",
+        overwrite=True,
+    ):
         """Write the wrapped dataframe as a TStore structure."""
-        raise NotImplementedError("Method not implemented yet.")
+        pandas_tslong = self.change_backend(new_backend="pandas")
+        pandas_tslong.to_tstore(
+            base_dir=base_dir,
+            partitioning=partitioning,
+            tstore_structure=tstore_structure,
+            overwrite=overwrite,
+        )
 
     @staticmethod
     def from_tstore(

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -13,7 +13,7 @@ from tstore.archive.checks import (
     check_ts_variables,
     check_tstore_ids,
 )
-from tstore.archive.io import get_id_var, get_time_var, get_ts_info
+from tstore.archive.io import get_id_var, get_ts_info
 from tstore.archive.ts.readers.pyarrow import open_ts
 from tstore.tslong.tslong import TSLong
 
@@ -60,7 +60,7 @@ class TSLongPyArrow(TSLong):
         tstore_ids = check_tstore_ids(tstore_ids, base_dir=base_dir)
         start_time, end_time = check_start_end_time(start_time, end_time)
         id_var = get_id_var(base_dir)
-        time_var = get_time_var(base_dir)
+        time_var = "time"
 
         # Get list of tslong for each ts_variable
         table, ts_variables_dict = _read_ts_variables(

--- a/tstore/tslong/pyarrow.py
+++ b/tstore/tslong/pyarrow.py
@@ -19,7 +19,6 @@ from tstore.tslong.tslong import TSLong
 
 if TYPE_CHECKING:
     # To avoid circular imports
-    from tstore.tsdf.pyarrow import TSDFPyArrow
     from tstore.tswide.pyarrow import TSWidePyArrow
 
 
@@ -95,10 +94,6 @@ class TSLongPyArrow(TSLong):
             ts_vars=ts_variables_dict,
             static_vars=static_vars,
         )
-
-    def to_tsdf(self) -> "TSDFPyArrow":
-        """Convert the wrapper into a TSDF object."""
-        raise NotImplementedError
 
     def to_tswide(self) -> "TSWidePyArrow":
         """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -46,8 +46,12 @@ class TSLong(TSWrapper):
         return super().__new__(cls)
 
     @staticmethod
+    @TSWrapper.copy_signature(__init__)
     def wrap(df: DataFrame, *args, **kwargs) -> "TSLong":
-        """Wrap a DataFrame in the appropriate TSLong subclass."""
+        """Wrap a DataFrame in the appropriate TSLong subclass.
+
+        Takes the same arguments as the TSLong constructor.
+        """
         # Lazy import to avoid circular imports
         from tstore.tslong.dask import TSLongDask
         from tstore.tslong.pandas import TSLongPandas

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -7,7 +7,7 @@ from tstore.tswrapper.tswrapper import TSWrapper
 
 
 class TSLong(TSWrapper):
-    """Abstract wrapper for a long-form timeseries dataframe."""
+    """Abstract wrapper for a long-form timeseries DataFrame."""
 
     def __init__(
         self,

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -1,9 +1,15 @@
 """Module defining the TSLong abstract wrapper."""
 
-from typing import Optional
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Optional
 
 from tstore.backend import DaskDataFrame, DataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame
 from tstore.tswrapper.tswrapper import TSWrapper
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.tsdf import TSDF
+    from tstore.tswide.tswide import TSWide
 
 
 class TSLong(TSWrapper):
@@ -72,3 +78,11 @@ class TSLong(TSWrapper):
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSLong object.")
+
+    @abstractmethod
+    def to_tsdf(self) -> "TSDF":
+        """Convert the wrapper into a TSDF object."""
+
+    @abstractmethod
+    def to_tswide(self) -> "TSWide":
+        """Convert the wrapper into a TSWide object."""

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -1,5 +1,7 @@
 """Module defining the TSLong abstract wrapper."""
 
+from typing import Optional
+
 from tstore.backend import DaskDataFrame, DataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame
 from tstore.tswrapper.tswrapper import TSWrapper
 
@@ -7,16 +9,44 @@ from tstore.tswrapper.tswrapper import TSWrapper
 class TSLong(TSWrapper):
     """Abstract wrapper for a long-form timeseries dataframe."""
 
+    def __init__(
+        self,
+        df: DataFrame,
+        id_var: str,
+        time_var: str = "time",
+        ts_vars: Optional[dict[str, list[str]]] = None,
+        static_vars: Optional[list[str]] = None,
+    ) -> None:
+        """Wrap a long-form timeseries DataFrame as a TSLong object.
+
+        Args:
+            df (DataFrame): DataFrame to wrap.
+            id_var (str): Name of the column containing the identifier variable.
+            time_var (str): Name of the column containing the time variable. Defaults to "time".
+            ts_vars (dict[str, list[str]]): Dictionary of named groups of column names.
+                Defaults to None, which will group all columns not in `static_vars` together.
+            static_vars (list[str]): List of column names that are static across time. Defaults to None.
+        """
+        super().__init__(df)
+        # Set attributes using __dict__ to not trigger __setattr__
+        self.__dict__.update(
+            {
+                "_tstore_id_var": id_var,
+                "_tstore_time_var": time_var,
+                "_tstore_ts_vars": ts_vars,
+                "_tstore_static_vars": static_vars,
+            },
+        )
+
     def __new__(cls, *args, **kwargs) -> "TSLong":
         """When calling TSLong() directly, return the appropriate subclass."""
         if cls is TSLong:
-            df = kwargs.get("df", args[0])
-            return TSLong.wrap(df)
+            return TSLong.wrap(*args, **kwargs)
 
         return super().__new__(cls)
 
     @staticmethod
-    def wrap(df: DataFrame) -> "TSLong":
+    def wrap(df: DataFrame, *args, **kwargs) -> "TSLong":
         """Wrap a DataFrame in the appropriate TSLong subclass."""
         # Lazy import to avoid circular imports
         from tstore.tslong.dask import TSLongDask
@@ -25,16 +55,16 @@ class TSLong(TSWrapper):
         from tstore.tslong.pyarrow import TSLongPyArrow
 
         if isinstance(df, DaskDataFrame):
-            return TSLongDask(df)
+            return TSLongDask(df, *args, **kwargs)
 
         if isinstance(df, PandasDataFrame):
-            return TSLongPandas(df)
+            return TSLongPandas(df, *args, **kwargs)
 
         if isinstance(df, PolarsDataFrame):
-            return TSLongPolars(df)
+            return TSLongPolars(df, *args, **kwargs)
 
         if isinstance(df, PyArrowDataFrame):
-            return TSLongPyArrow(df)
+            return TSLongPyArrow(df, *args, **kwargs)
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSLong object.")

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -34,6 +34,17 @@ class TSLong(TSWrapper):
             static_vars (list[str]): List of column names that are static across time. Defaults to None.
         """
         super().__init__(df)
+
+        if static_vars is None:
+            static_vars = []
+
+        if ts_vars is None:
+            ts_vars = {
+                "ts_variable": [
+                    col for col in df.columns if col != id_var and col != time_var and col not in static_vars
+                ],
+            }
+
         # Set attributes using __dict__ to not trigger __setattr__
         self.__dict__.update(
             {

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -123,9 +123,12 @@ class TSLong(TSWrapper):
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSLong object.")
 
-    @abstractmethod
     def to_tsdf(self) -> "TSDF":
         """Convert the wrapper into a TSDF object."""
+        dask_tslong = self.change_backend(new_backend="dask")
+        dask_tsdf = dask_tslong.to_tsdf()
+        tsdf = dask_tsdf.change_backend(new_backend=self.current_backend)
+        return tsdf
 
     @abstractmethod
     def to_tswide(self) -> "TSWide":

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -45,6 +45,10 @@ class TSLong(TSWrapper):
                 ],
             }
 
+        # TODO: Adapt to Polar and PyArrow
+        if isinstance(df, (DaskDataFrame, PandasDataFrame)):
+            df[id_var] = df[id_var].astype("large_string[pyarrow]")
+
         # Set attributes using __dict__ to not trigger __setattr__
         self.__dict__.update(
             {

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -3,7 +3,15 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Optional
 
-from tstore.backend import DaskDataFrame, DataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame
+from tstore.backend import (
+    Backend,
+    DaskDataFrame,
+    DataFrame,
+    PandasDataFrame,
+    PolarsDataFrame,
+    PyArrowDataFrame,
+    change_backend,
+)
 from tstore.tswrapper.tswrapper import TSWrapper
 
 if TYPE_CHECKING:
@@ -65,6 +73,11 @@ class TSLong(TSWrapper):
             return TSLong.wrap(*args, **kwargs)
 
         return super().__new__(cls)
+
+    def change_backend(self, new_backend: Backend) -> "TSLong":
+        """Return a new wrapper with the dataframe converted to a different backend."""
+        new_df = change_backend(self._obj, new_backend, index_var=self._tstore_time_var)
+        return self._rewrap(new_df)
 
     @staticmethod
     @TSWrapper.copy_signature(__init__)

--- a/tstore/tslong/tslong.py
+++ b/tstore/tslong/tslong.py
@@ -14,6 +14,7 @@ from tstore.backend import (
     PolarsDataFrame,
     PyArrowDataFrame,
     change_backend,
+    re_set_dataframe_index,
 )
 from tstore.tswrapper.tswrapper import TSWrapper
 
@@ -56,6 +57,9 @@ class TSLong(TSWrapper):
             schema = schema.remove(field_index)
             schema = schema.insert(field_index, pa.field(id_var, pa.large_string()))
             df = df.cast(target_schema=schema)
+
+        # Ensure correct index column
+        df = re_set_dataframe_index(df, index_var=time_var)
 
         super().__init__(df)
 

--- a/tstore/tswide/__init__.py
+++ b/tstore/tswide/__init__.py
@@ -11,7 +11,7 @@ from tstore.tswide.pyarrow import TSWidePyArrow
 from tstore.tswide.tswide import TSWide
 
 
-def open_tswide(base_dir: Union[str, Path], *args, backend: Backend = "pandas", **kwargs):
+def open_tswide(base_dir: Union[str, Path], *args, backend: Backend = "dask", **kwargs):
     """Read a TStore file structure as a TSWide object."""
     ts_wide_classes = {
         "dask": TSWideDask,

--- a/tstore/tswide/dask.py
+++ b/tstore/tswide/dask.py
@@ -1,6 +1,12 @@
 """Module defining the TSWideDask wrapper."""
 
+from typing import TYPE_CHECKING
+
 from tstore.tswide.tswide import TSWide
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.dask import TSLongDask
 
 
 class TSWideDask(TSWide):
@@ -11,6 +17,10 @@ class TSWideDask(TSWide):
         raise NotImplementedError
 
     @staticmethod
-    def from_tstore(base_dir) -> "TSWideDask":
+    def from_tstore(base_dir: str) -> "TSWideDask":
         """Open a TStore file structure as a TSWideDask wrapper around a Dask long dataframe."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongDask":
+        """Convert the wrapper into a TSLongDask object."""
         raise NotImplementedError

--- a/tstore/tswide/pandas.py
+++ b/tstore/tswide/pandas.py
@@ -1,6 +1,12 @@
 """Module defining the TSWidePandas wrapper."""
 
+from typing import TYPE_CHECKING
+
 from tstore.tswide.tswide import TSWide
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.pandas import TSLongPandas
 
 
 class TSWidePandas(TSWide):
@@ -11,6 +17,10 @@ class TSWidePandas(TSWide):
         raise NotImplementedError
 
     @staticmethod
-    def from_tstore(base_dir) -> "TSWidePandas":
+    def from_tstore(base_dir: str) -> "TSWidePandas":
         """Open a TStore file structure as a TSWidePandas wrapper around a Pandas long dataframe."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongPandas":
+        """Convert the wrapper into a TSLongPandas object."""
         raise NotImplementedError

--- a/tstore/tswide/polars.py
+++ b/tstore/tswide/polars.py
@@ -1,6 +1,12 @@
 """Module defining the TSWidePolars wrapper."""
 
+from typing import TYPE_CHECKING
+
 from tstore.tswide.tswide import TSWide
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.polars import TSLongPolars
 
 
 class TSWidePolars(TSWide):
@@ -11,6 +17,10 @@ class TSWidePolars(TSWide):
         raise NotImplementedError
 
     @staticmethod
-    def from_tstore(base_dir) -> "TSWidePolars":
+    def from_tstore(base_dir: str) -> "TSWidePolars":
         """Open a TStore file structure as a TSWidePolars wrapper around a Polars long dataframe."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongPolars":
+        """Convert the wrapper into a TSLongPolars object."""
         raise NotImplementedError

--- a/tstore/tswide/pyarrow.py
+++ b/tstore/tswide/pyarrow.py
@@ -1,6 +1,12 @@
 """Module defining the TSWidePyArrow wrapper."""
 
+from typing import TYPE_CHECKING
+
 from tstore.tswide.tswide import TSWide
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tslong.pyarrow import TSLongPyArrow
 
 
 class TSWidePyArrow(TSWide):
@@ -11,6 +17,10 @@ class TSWidePyArrow(TSWide):
         raise NotImplementedError
 
     @staticmethod
-    def from_tstore(base_dir) -> "TSWidePyArrow":
+    def from_tstore(base_dir: str) -> "TSWidePyArrow":
         """Open a TStore file structure as a TSWidePyArrow wrapper around a PyArrow long dataframe."""
+        raise NotImplementedError
+
+    def to_tslong(self) -> "TSLongPyArrow":
+        """Convert the wrapper into a TSLongPyArrow object."""
         raise NotImplementedError

--- a/tstore/tswide/tswide.py
+++ b/tstore/tswide/tswide.py
@@ -1,7 +1,15 @@
 """Module defining the TSWide abstract wrapper."""
 
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
 from tstore.backend import DaskDataFrame, DataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame
 from tstore.tswrapper.tswrapper import TSWrapper
+
+if TYPE_CHECKING:
+    # To avoid circular imports
+    from tstore.tsdf.tsdf import TSDF
+    from tstore.tslong.tslong import TSLong
 
 
 class TSWide(TSWrapper):
@@ -38,3 +46,11 @@ class TSWide(TSWrapper):
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSWide object.")
+
+    def to_tsdf(self) -> "TSDF":
+        """Convert the wrapper into a TSDF object."""
+        return self.to_tslong().to_tsdf()
+
+    @abstractmethod
+    def to_tslong(self) -> "TSLong":
+        """Convert the wrapper into a TSLong object."""

--- a/tstore/tswide/tswide.py
+++ b/tstore/tswide/tswide.py
@@ -1,9 +1,15 @@
 """Module defining the TSWide abstract wrapper."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-from tstore.backend import DaskDataFrame, DataFrame, PandasDataFrame, PolarsDataFrame, PyArrowDataFrame
+from tstore.backend import (
+    DaskDataFrame,
+    DataFrame,
+    PandasDataFrame,
+    PolarsDataFrame,
+    PyArrowDataFrame,
+)
 from tstore.tswrapper.tswrapper import TSWrapper
 
 if TYPE_CHECKING:
@@ -15,6 +21,52 @@ if TYPE_CHECKING:
 class TSWide(TSWrapper):
     """Abstract wrapper for a wide-form timeseries DataFrame."""
 
+    def __init__(
+        self,
+        df: DataFrame,
+        id_var: str,
+        time_var: str = "time",
+        ts_vars: Optional[dict[str, list[str]]] = None,
+        static_vars: Optional[list[str]] = None,
+    ) -> None:
+        """Wrap a wide-form timeseries DataFrame as a TSWide object.
+
+        Args:
+            df (DataFrame): DataFrame to wrap.
+            id_var (str): Name of the column containing the identifier variable.
+            time_var (str): Name of the column containing the time variable. Defaults to "time".
+            ts_vars (dict[str, list[str]]): Dictionary of named groups of column names.
+                Defaults to None, which will group all columns not in `static_vars` together.
+            static_vars (list[str]): List of column names that are static across time. Defaults to None.
+        """
+        # TODO: Cast id_var to large string
+        # df = cast_column_to_large_string(df, id_var)
+
+        # TODO: Ensure correct index column
+        # df = re_set_dataframe_index(df, index_var=time_var)
+
+        super().__init__(df)
+
+        if static_vars is None:
+            static_vars = []
+
+        if ts_vars is None:
+            ts_vars = {
+                "ts_variable": [
+                    col for col in df.columns if col != id_var and col != time_var and col not in static_vars
+                ],
+            }
+
+        # Set attributes using __dict__ to not trigger __setattr__
+        self.__dict__.update(
+            {
+                "_tstore_id_var": id_var,
+                "_tstore_time_var": time_var,
+                "_tstore_ts_vars": ts_vars,
+                "_tstore_static_vars": static_vars,
+            },
+        )
+
     def __new__(cls, *args, **kwargs) -> "TSWide":
         """When calling TSWide() directly, return the appropriate subclass."""
         if cls is TSWide:
@@ -24,7 +76,7 @@ class TSWide(TSWrapper):
         return super().__new__(cls)
 
     @staticmethod
-    def wrap(df: DataFrame) -> "TSWide":
+    def wrap(df: DataFrame, *args, **kwargs) -> "TSWide":
         """Wrap a DataFrame in the appropriate TSWide subclass."""
         # Lazy import to avoid circular imports
         from tstore.tswide.dask import TSWideDask
@@ -33,16 +85,16 @@ class TSWide(TSWrapper):
         from tstore.tswide.pyarrow import TSWidePyArrow
 
         if isinstance(df, DaskDataFrame):
-            return TSWideDask(df)
+            return TSWideDask(df, *args, **kwargs)
 
         if isinstance(df, PandasDataFrame):
-            return TSWidePandas(df)
+            return TSWidePandas(df, *args, **kwargs)
 
         if isinstance(df, PolarsDataFrame):
-            return TSWidePolars(df)
+            return TSWidePolars(df, *args, **kwargs)
 
         if isinstance(df, PyArrowDataFrame):
-            return TSWidePyArrow(df)
+            return TSWidePyArrow(df, *args, **kwargs)
 
         type_path = f"{type(df).__module__}.{type(df).__qualname__}"
         raise TypeError(f"Cannot wrap type {type_path} as a TSWide object.")

--- a/tstore/tswide/tswide.py
+++ b/tstore/tswide/tswide.py
@@ -5,7 +5,7 @@ from tstore.tswrapper.tswrapper import TSWrapper
 
 
 class TSWide(TSWrapper):
-    """Abstract wrapper for a wide-form timeseries dataframe."""
+    """Abstract wrapper for a wide-form timeseries DataFrame."""
 
     def __new__(cls, *args, **kwargs) -> "TSWide":
         """When calling TSWide() directly, return the appropriate subclass."""

--- a/tstore/tswrapper/tswrapper.py
+++ b/tstore/tswrapper/tswrapper.py
@@ -68,7 +68,10 @@ class Proxy:
 
 
 class TSWrapper(ABC, Proxy):
-    """Abstract base class for dataframe tstore wrappers."""
+    """Abstract base class for dataframe tstore wrappers.
+
+    Added attributes should be prefixed with `_tstore_` and added to the `__dict__` in the `__init__` method.
+    """
 
     def __init__(self, df: DataFrame):
         super().__init__(df)
@@ -85,12 +88,15 @@ class TSWrapper(ABC, Proxy):
     def change_backend(self, new_backend: Backend) -> "TSWrapper":
         """Return a new wrapper with the dataframe converted to a different backend."""
         new_df = change_backend(self._obj, new_backend)
-        return self.wrap(new_df)
+        kwargs = {
+            key.removeprefix("_tstore_"): value for key, value in self.__dict__.items() if key.startswith("_tstore_")
+        }
+        return self.wrap(new_df, **kwargs)
 
     @classmethod
-    def wrap(cls, df: DataFrame):
+    def wrap(cls, df: DataFrame, *args, **kwargs):
         """Wrap a DataFrame in the appropriate TSWrapper subclass."""
-        return cls(df)
+        return cls(df, *args, **kwargs)
 
     def __getattr__(self, key):
         """Delegate attribute access to the wrapped dataframe."""

--- a/tstore/tswrapper/tswrapper.py
+++ b/tstore/tswrapper/tswrapper.py
@@ -7,7 +7,7 @@ from typing import Callable, Union
 
 import pandas as pd
 
-from tstore.backend import Backend, DataFrame, change_backend
+from tstore.backend import Backend, DataFrame, change_backend, get_backend
 
 
 def copy_signature(source: Callable) -> Callable:
@@ -101,6 +101,11 @@ class TSWrapper(ABC, Proxy):
         """Return a new wrapper with the dataframe converted to a different backend."""
         new_df = change_backend(self._obj, new_backend)
         return self._rewrap(new_df)
+
+    @property
+    def current_backend(self) -> Backend:
+        """Return the backend of the wrapped dataframe."""
+        return get_backend(self._obj)
 
     @classmethod
     @copy_signature(__init__)

--- a/tutorials/01_example_ts.py
+++ b/tutorials/01_example_ts.py
@@ -35,9 +35,9 @@ ts_pd = TS(df_pd)
 ts_dask = TS(df_dask)
 
 # Get time series data
-ts_pd.data
-ts_dask.data
-ts_dask.data.compute()
+ts_pd._obj
+ts_dask._obj
+ts_dask._obj.compute()
 
 # See TS methods
 dir(ts_pd)
@@ -77,7 +77,7 @@ ts_dask.to_disk(fpath)
 
 # Dask code
 ts = TS.from_file(fpath, partitions=[])  # logic of partitions not implemented ...
-ts.data
+ts._obj
 
 
 ####-------------------------------------.


### PR DESCRIPTION
# Prework

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ltelab/tstore/blob/main/CODE_OF_CONDUCT.md).
- [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ltelab/tstore/blob/main/CONTRIBUTING.md).
- [x] I have already submitted an [issue](https://github.com/ltelab/tstore/issues) or [discussion thread](https://github.com/ltelab/tstore/discussions) to discuss my idea with the maintainers.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ltelab/tstore/blob/main/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Tutorial
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and communicate accordingly:

**The PR fulfills these requirements:**

- [x] It's submitted to the branch named as follow:
  - Fix a bug: `bugfix-<some_key>-<word>`
  - Improve the doc: `doc-<some_key>-<word>`
  - Improve a tutorial `tutorial-<some_key>-<word>`
  - Add a new feature: `feature-<some_key>-<word>`
  - Refactor some code: `refactor-<some_key>-<word>`
  - Optimize some code: `optimize-<some_key>-<word>`
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Don't forget to link PR to issue if you are solving one.
- [x] All tests are passing.
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

# Related GitHub issues and pull requests

- Fix: #12 

# Summary

- changed signature of `TSLong` wrappers:
```
TSLong(
    df: DataFrame,
    id_var: str,
    time_var: str = "time",
    ts_vars: Optional[dict[str, list[str]]] = None,
    static_vars: Optional[list[str]] = None,
)
```
  for example:
```
tslong = tstore.TSLong.wrap(
    df,
    id_var="tstore_id",
    time_var="time",
    ts_vars={"ts_var1": ["var1", "var2"], "ts_var2": ["var3", "var4"]},
    static_vars=["static_var1", "static_var2"],
)
```
- changed signature of `TSDF` wrappers:
```
TSDF(
    df: DataFrame,
    id_var: str,
)
```
- add `TSLong.to_tsdf` method
- add `TSDF.to_tslong` method
- remove `time_var` from saved metadata in tstore
- only use index with Pandas and Dask dataframes for time
- adapt `TS` class wrapper to all backends